### PR TITLE
Adds Storybook table of contents component

### DIFF
--- a/stories/tableOfContents/TableOfContents.stories.js
+++ b/stories/tableOfContents/TableOfContents.stories.js
@@ -1,0 +1,25 @@
+import TableOfContents from './tableOfContents.handlebars'
+
+export default {
+  title: 'Components/Table of Contents',
+  component: TableOfContents,
+  args: {
+    ariaLabel: 'table of contents',
+    listItems: [
+      { text: 'Purpose', active: true },
+      { text: 'Objectives', active: false },
+      { text: 'Mandate', active: false },
+      { text: 'Scope', active: false },
+      { text: 'Challenges', active: false },
+      { text: 'Principles', active: false }
+    ]
+  }
+}
+
+export const Colors = (args) => {
+  const colors = ['toc--neutral', 'toc--blue', 'toc--orange']
+  const tocs = colors.map(c => TableOfContents({ class: c, ...args })).join('')
+  return tocs
+}
+
+export const WithTitle = (args) => TableOfContents({ class: 'toc--neutral', title: 'Digital Preservation Policy', ...args })

--- a/stories/tableOfContents/listItems.json
+++ b/stories/tableOfContents/listItems.json
@@ -1,0 +1,13 @@
+[
+  {"text": "Purpose", "active": true},
+  {"text": "Objectives", "active": false},
+  {"text": "Mandate", "active": false},
+  {"text": "Scope", "active": false},
+  {"text": "Challenges", "active": false},
+  {"text": "Principles", "active": false},
+  {"text": "Categories of Commitment", "active": false},
+  {"text": "Frequency of Policy Review", "active": false},
+  {"text": "Roles and Responsibilities", "active": false},
+  {"text": "Appendix A: Glossary", "active": false},
+  {"text": "Appendix B: Sources Consulted", "active": false}
+]

--- a/stories/tableOfContents/tableOfContents.handlebars
+++ b/stories/tableOfContents/tableOfContents.handlebars
@@ -1,0 +1,11 @@
+<nav class="toc {{class}}" role="navigation" aria-label="{{ariaLabel}}">
+  <a href="#documentation" class="visually-hidden">skip navigation</a>
+  {{#if title}}
+  <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
+  {{/if}}
+  <div class="toc__list">
+    {{#each listItems}}
+    <a class="toc__list-item {{#if this.active}}active{{/if}}" href="#{{this.text}}">{{this.text}}</a>
+    {{/each}}
+  </div>
+</nav>

--- a/stories/tableOfContents/tableOfContents.handlebars
+++ b/stories/tableOfContents/tableOfContents.handlebars
@@ -1,5 +1,4 @@
 <nav class="toc {{class}}" role="navigation" aria-label="{{ariaLabel}}">
-  <a href="#documentation" class="visually-hidden">skip navigation</a>
   {{#if title}}
   <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
   {{/if}}


### PR DESCRIPTION
Adds a table of contents component, which attempts to combine the implementation in docs.rockarch.org as well as rockarch.org. I've provided the list items as an editable array in case people want to construct their own TOC list.

fixes #17 