### PR TITLE
Customize selector class name linting for BEM

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -10,6 +10,12 @@
     "a11y/media-prefers-reduced-motion": true,
     "a11y/no-outline-none": true,
     "a11y/selector-pseudo-class-focus": true,
-    "at-rule-no-unknown": null
+    "at-rule-no-unknown": null,
+    "selector-class-pattern": [
+      "^[a-z]([a-z0-9-]+)?(__([a-z0-9]+-?)+)?(--([a-z0-9]+-?)+){0,2}$",
+      {
+        "message": "Class names should match the BEM naming convention"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Fixes #72 

Specifies a stylelint rule with a regex to check BEM naming. Modifies the default styleint rules which only allow hyphens in class names. I adapted the regex from [this GitHub issue comment](https://github.com/bjankord/stylelint-config-sass-guidelines/issues/20#issuecomment-349972873).

I looked into adding the [styleint-selector-bem-pattern](https://github.com/simonsmith/stylelint-selector-bem-pattern) plugin, but there is a bunch of stuff that it necessitates including defining component names in the scss files and seemed like overkill.

