### PR TITLE
Adds button styles

### DIFF
--- a/stories/button/Button.stories.js
+++ b/stories/button/Button.stories.js
@@ -13,12 +13,12 @@ export const sizes = (args) => {
   return buttons
 }
 
-export const icons = (args) => Button({ iconAfter: 'email', class: 'btn-primary', ...args })
+export const icons = (args) => Button({ iconAfter: 'email', class: 'btn--lg btn--light-blue', ...args })
 icons.args = {
   iconBefore: 'email',
   iconAfter: ''
 }
 
-export const fullWidth = (args) => Button({ class: 'btn--block', ...args })
+export const fullWidth = (args) => Button({ class: 'btn--block btn--blue btn--lg', ...args })
 
 export const link = (args) => Link(args)

--- a/stories/button/Button.stories.mdx
+++ b/stories/button/Button.stories.mdx
@@ -21,6 +21,7 @@ saving their information.
   in", or "Save for later".
 - Do not use buttons as navigational elements. Instead, use links when the
   desired action is to take the user to a new page.
+- Use the base "btn" class in addition to a class which specifies a color or size.
 
 ## Related components
 
@@ -31,7 +32,7 @@ No related components.
 
 ## Known issues
 
-No known issues.
+`btn--orange` does not meet WCAG requirements for color contrast.
 
 ## Colors
 Buttons come in a variety of colors:

--- a/stories/button/Button.stories.mdx
+++ b/stories/button/Button.stories.mdx
@@ -22,6 +22,8 @@ saving their information.
 - Do not use buttons as navigational elements. Instead, use links when the
   desired action is to take the user to a new page.
 - Use the base "btn" class in addition to a class which specifies a color or size.
+- When using the transparent button, make sure to check that the button will meet
+  the contrast threshold against the background it is being used on.
 
 ## Related components
 

--- a/stories/button/button.handlebars
+++ b/stories/button/button.handlebars
@@ -1,9 +1,9 @@
 <button class="btn {{class}}">
   {{#if iconBefore}}
-  <span class="material-icons" aria-hidden="true">{{iconBefore}}</span>
+  <span class="material-icon material-icon--space-after" aria-hidden="true">{{iconBefore}}</span>
   {{/if}}
     {{text}}
   {{#if iconAfter}}
-  <span class="material-icons" aria-hidden="true">{{iconAfter}}</span>
+  <span class="material-icon material-icon--space-before" aria-hidden="true">{{iconAfter}}</span>
   {{/if}}
 </button>

--- a/stories/button/colors.json
+++ b/stories/button/colors.json
@@ -1,9 +1,10 @@
 [
-  "btn-blue",
-  "btn--navy",
-  "btn--orange",
-  "btn--transparent",
-  "btn--gray",
-  "btn--dark-gray",
-  "btn--black"
+  "btn--sm btn--light-blue",
+  "btn--sm btn--blue",
+  "btn--sm btn--navy",
+  "btn--sm btn--orange",
+  "btn--sm btn--transparent",
+  "btn--sm btn--gray",
+  "btn--sm btn--dark-gray",
+  "btn--sm btn--black"
 ]

--- a/stories/button/link.handlebars
+++ b/stories/button/link.handlebars
@@ -1,1 +1,1 @@
-<a href="#" class="btn btn--orange">{{text}}</a>
+<a href="#" class="btn btn--sm btn--orange">{{text}}</a>

--- a/stories/button/sizes.json
+++ b/stories/button/sizes.json
@@ -1,5 +1,5 @@
 [
-  "btn--sm",
-  "btn--md",
-  "btn--lg"
+  "btn--navy btn--sm",
+  "btn--navy btn--md",
+  "btn--navy btn--lg"
 ]

--- a/stories/header/dropdownItems.handlebars
+++ b/stories/header/dropdownItems.handlebars
@@ -4,7 +4,7 @@
     <li class="nav__item--dropdown">
       <button aria-expanded="false" aria-controls="id-collections-menu">
         Collections
-        <span aria-hidden="true" class="material-icons">keyboard_arrow_down</span>
+        <span aria-hidden="true" class="material-icon">keyboard_arrow_down</span>
       </button>
       <ul id="id-collections-menu" class="nav__list--dropdown">
         <li class="nav__item">
@@ -43,7 +43,7 @@
     <li class="nav__item--dropdown">
       <button aria-expanded="false" aria-controls="id-resources-menu">
         Resources
-        <span aria-hidden="true" class="material-icons">keyboard_arrow_down</span>
+        <span aria-hidden="true" class="material-icon">keyboard_arrow_down</span>
       </button>
       <ul id="id-resources-menu" class="nav__list--dropdown" hidden="" style="display: none;">
         <li class="nav__item">
@@ -94,7 +94,7 @@
     <li class="nav__item--dropdown">
       <button aria-expanded="false" aria-controls="id-about-menu">
         About Us
-        <span aria-hidden="true" class="material-icons">keyboard_arrow_down</span>
+        <span aria-hidden="true" class="material-icon">keyboard_arrow_down</span>
       </button>
       <ul id="id-about-menu" class="nav__list--dropdown" hidden="" style="display: none;">
         <li class="nav__item">
@@ -127,7 +127,7 @@
 
   <div class="hide-on-lg-up">
     <button id="nav-toggle" aria-label="menu" aria-expanded="false">
-      <span class="material-icons" aria-hidden="true">menu</span>
+      <span class="material-icon" aria-hidden="true">menu</span>
     </button>
   </div>
 

--- a/stories/header/navItems.handlebars
+++ b/stories/header/navItems.handlebars
@@ -1,19 +1,19 @@
 <nav class="nav" aria-label="Main">
   <ul class="nav__list">
     <li class="nav__item">
-      <a class="nav__link" href="https://raccess.rockarch.org/" id="raccess">Sign in to RACcess <span class="material-icons" aria-hidden="true">arrow_right_alt</span></a>
+      <a class="nav__link" href="https://raccess.rockarch.org/" id="raccess">Sign in to RACcess <span class="material-icon" aria-hidden="true">arrow_right_alt</span></a>
     </li>
     <li class="nav__item">
-      <a class="nav__link" href="/list/" id="list">My List (146) <span class="material-icons" aria-hidden="true">arrow_right_alt</span></a>
+      <a class="nav__link" href="/list/" id="list">My List (146) <span class="material-icon" aria-hidden="true">arrow_right_alt</span></a>
     </li>
   </ul>
   <div class="dropdown hide-on-lg-up">
     <button class="btn nav-mobile__btn closed" tabindex="0" aria-expanded="false">
-      <span class="material-icons" aria-hidden="true">menu</span>
+      <span class="material-icon" aria-hidden="true">menu</span>
     </button>
     <ul class="dropdown__list dropdown__list--mobile dropdown__list--slide-left closed">
-      <li><a id="menu-item-0" class="btn btn--navy btn--mobile-dropdown" href="https://raccess.rockarch.org" tabindex="-1">Sign in to RACcess<span class="material-icons" aria-hidden="true">east</span></a></li>
-      <li><a id="menu-item-1" class="btn btn--navy btn--mobile-dropdown" href="/list" tabindex="-1">My List<span class="material-icons" aria-hidden="true">east</span></a></li>
+      <li><a id="menu-item-0" class="btn btn--navy btn--mobile-dropdown" href="https://raccess.rockarch.org" tabindex="-1">Sign in to RACcess<span class="material-icon" aria-hidden="true">east</span></a></li>
+      <li><a id="menu-item-1" class="btn btn--navy btn--mobile-dropdown" href="/list" tabindex="-1">My List<span class="material-icon" aria-hidden="true">east</span></a></li>
     </ul>
   </div>
 </nav>

--- a/stories/modal/modal.handlebars
+++ b/stories/modal/modal.handlebars
@@ -2,7 +2,7 @@
   <div class="modal__header">
     <h2 class="modal__header-title">{{title}}</h2>
     <button class="modal__header-button" aria-label="Close">
-      <span class="material-icons" aria-hidden="true">close</span>
+      <span class="material-icon" aria-hidden="true">close</span>
     </button>
   </div>
   <div class="modal__body">

--- a/stories/search/search.handlebars
+++ b/stories/search/search.handlebars
@@ -19,7 +19,7 @@
       </div>
       {{/if}}
       {{#if button}}
-      <button type="submit" class="btn btn--search"><span class="material-icons" aria-hidden="true">search</span></button>
+      <button type="submit" class="btn btn--search"><span class="material-icon" aria-hidden="true">search</span></button>
       {{/if}}
     </div>
     {{#if controlsBlock}}

--- a/stylesheets/abstracts/_variables.scss
+++ b/stylesheets/abstracts/_variables.scss
@@ -98,6 +98,8 @@ $break-lg: 1024px !default;
 ///   $base-url: 'http://cdn.example.com/assets/';
 $base-url: '/assets/' !default;
 
+$transition-default: all 0.2s ease;
+
 :export {
   black: $black;
   crustaorange: $crusta-orange;

--- a/stylesheets/abstracts/_variables.scss
+++ b/stylesheets/abstracts/_variables.scss
@@ -101,8 +101,6 @@ $break-lg: 1024px !default;
 ///   $base-url: 'http://cdn.example.com/assets/';
 $base-url: '/assets/' !default;
 
-$transition-default: all 0.2s ease;
-
 :export {
   black: $black;
   crustaorange: $crusta-orange;

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -134,6 +134,12 @@
   background-color: transparent;
   border: 1px solid $dark-grey;
   color: $mortar-grey;
+
+  &:hover,
+  &:focus {
+    border-color: darken($dark-grey, 20%);
+    color: darken($mortar-grey, 20%);
+  }
 }
 
 .btn--gray {

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -6,7 +6,9 @@
 * Defines base styles for buttons.
 **/
 .btn {
-  border-radius: 3px;
+  @include transition-default;
+
+  border-radius: $border-radius-default;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;
@@ -25,15 +27,6 @@
   &:hover,
   &:focus {
     text-decoration: none;
-  }
-}
-
-/**
-* Adds transition if user has not declared a reduced motion preference.
-**/
-@media screen and (prefers-reduced-motion: no-preference) {
-  .btn {
-    transition: $transition-default;
   }
 }
 

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -2,7 +2,10 @@
 // This file contains all styles related to the button component.
 // -----------------------------------------------------------------------------
 
-@media screen and (prefers-reduced-motion: reduce) {
+/**
+* Defines base styles for buttons.
+**/
+@media screen and (prefers-reduced-motion: no-preference) {
   .btn {
     border-radius: 3px;
     border-style: solid;
@@ -13,7 +16,7 @@
     letter-spacing: 1.5px;
     text-decoration: none;
     text-transform: uppercase;
-    transition: none;
+    transition: $transition-default;
     vertical-align: middle;
 
     &:disabled {
@@ -28,35 +31,27 @@
   }
 }
 
-.btn {
-  border-radius: 3px;
-  border-style: solid;
-  border-width: 1px;
-  cursor: pointer;
-  display: inline-block;
-  font-family: $sans-serif-stack;
-  letter-spacing: 1.5px;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: $transition-default;
-  vertical-align: middle;
-
-  &:disabled {
-    cursor: unset;
-    opacity: 0.7;
-  }
-
-  &:hover,
-  &:focus {
-    text-decoration: none;
+/**
+* Removes transitions for users who have requested reduced motion.
+**/
+@media screen and (prefers-reduced-motion: reduce) {
+  .btn {
+    transition-duration: 0s;
+    transition-property: none;
   }
 }
 
+/**
+* Styles for buttons which take up the full width of their parent element.
+**/
 .btn--block {
   display: flex;
   width: 100%;
 }
 
+/**
+* Styles for button sizes. Font sizes and padding are adjusted for each size.
+**/
 .btn--sm {
   font-size: 10px;
   font-weight: bold;
@@ -91,6 +86,10 @@
   }
 }
 
+/**
+* Styles for button colors. Sets background, border and text color, and adjusts
+* each on hover and/or focus.
+**/
 .btn--blue {
   background-color: $yale-blue;
   border-color: $yale-blue;

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -1,3 +1,186 @@
 // -----------------------------------------------------------------------------
 // This file contains all styles related to the button component.
 // -----------------------------------------------------------------------------
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .btn {
+    border-radius: 3px;
+    border-style: solid;
+    border-width: 1px;
+    cursor: pointer;
+    display: inline-block;
+    font-family: $sans-serif-stack;
+    letter-spacing: 1.5px;
+    text-decoration: none;
+    text-transform: uppercase;
+    transition: none;
+    vertical-align: middle;
+
+    &:disabled {
+      cursor: unset;
+      opacity: 0.7;
+    }
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+}
+
+.btn {
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-family: $sans-serif-stack;
+  letter-spacing: 1.5px;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: $transition-default;
+  vertical-align: middle;
+
+  &:disabled {
+    cursor: unset;
+    opacity: 0.7;
+  }
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+}
+
+.btn--block {
+  display: flex;
+  width: 100%;
+}
+
+.btn--sm {
+  font-size: 10px;
+  font-weight: bold;
+  line-height: 16px;
+  padding: 8px 10px;
+
+  .material-icon {
+    font-size: 16px;
+    line-height: 16px;
+  }
+}
+
+.btn--md {
+  font-size: 12px;
+  line-height: 15px;
+  padding: 13px 14px;
+
+  .material-icon {
+    font-size: 20px;
+    line-height: 15px;
+  }
+}
+
+.btn--lg {
+  font-size: 14px;
+  line-height: 18px;
+  padding: 18px;
+
+  .material-icon {
+    font-size: 20px;
+    line-height: 17px;
+  }
+}
+
+.btn--blue {
+  background-color: $yale-blue;
+  border-color: $yale-blue;
+  color: $white;
+
+  &:hover,
+  &:focus {
+    background-color: darken($yale-blue, 10%);
+    border-color: darken($yale-blue, 10%);
+    color: $white;
+  }
+}
+
+.btn--light-blue {
+  background-color: $solitude-blue;
+  border-color: $regal-blue;
+  color: $regal-blue;
+
+  &:hover,
+  &:focus {
+    background-color: darken($solitude-blue, 10%);
+    color: $regal-blue;
+  }
+}
+
+.btn--navy {
+  background-color: $regal-blue;
+  border-color: $regal-blue;
+  color: $white;
+
+  &:hover,
+  &:focus {
+    background-color: lighten($regal-blue, 10%);
+    border-color: lighten($regal-blue, 10%);
+    color: $white;
+  }
+}
+
+.btn--orange {
+  background-color: $flame-orange;
+  border-color: $flame-orange;
+  color: $white;
+
+  &:hover,
+  &:focus {
+    background-color: darken($flame-orange, 10%);
+    border-color: darken($flame-orange, 10%);
+    color: $desert-grey;
+  }
+}
+
+.btn--transparent {
+  background-color: transparent;
+  border: 1px solid $dark-grey;
+  color: $mortar-grey;
+}
+
+.btn--gray {
+  background-color: $desert-grey;
+  border-color: $dark-grey;
+  color: $mortar-grey;
+
+  &:hover,
+  &:focus {
+    background-color: darken($desert-grey, 5%);
+    color: $mortar-grey;
+  }
+}
+
+.btn--dark-gray {
+  background-color: $dark-grey;
+  border-color: $dark-grey;
+  color: $black;
+
+  &:hover,
+  &:focus {
+    background-color: darken($dark-grey, 5%);
+    border-color: darken($dark-grey, 5%);
+    color: $black;
+  }
+}
+
+.btn--black {
+  background-color: $black;
+  border-color: $white;
+  color: $white;
+
+  &:hover,
+  &:focus {
+    background-color: lighten($black, 20%);
+    color: $white;
+  }
+}

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -5,39 +5,35 @@
 /**
 * Defines base styles for buttons.
 **/
-@media screen and (prefers-reduced-motion: no-preference) {
-  .btn {
-    border-radius: 3px;
-    border-style: solid;
-    border-width: 1px;
-    cursor: pointer;
-    display: inline-block;
-    font-family: $sans-serif-stack;
-    letter-spacing: 1.5px;
+.btn {
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-block;
+  font-family: $sans-serif-stack;
+  letter-spacing: 1.5px;
+  text-decoration: none;
+  text-transform: uppercase;
+  vertical-align: middle;
+
+  &:disabled {
+    cursor: unset;
+    opacity: 0.7;
+  }
+
+  &:hover,
+  &:focus {
     text-decoration: none;
-    text-transform: uppercase;
-    transition: $transition-default;
-    vertical-align: middle;
-
-    &:disabled {
-      cursor: unset;
-      opacity: 0.7;
-    }
-
-    &:hover,
-    &:focus {
-      text-decoration: none;
-    }
   }
 }
 
 /**
-* Removes transitions for users who have requested reduced motion.
+* Adds transition if user has not declared a reduced motion preference.
 **/
-@media screen and (prefers-reduced-motion: reduce) {
+@media screen and (prefers-reduced-motion: no-preference) {
   .btn {
-    transition-duration: 0s;
-    transition-property: none;
+    transition: $transition-default;
   }
 }
 

--- a/stylesheets/components/_icon.scss
+++ b/stylesheets/components/_icon.scss
@@ -2,7 +2,7 @@
 // This file contains all styles related to icons
 // -----------------------------------------------------------------------------
 
-.material-icons {
+.material-icon {
   direction: ltr;
   display: inline-block;
   font-family: $icons;
@@ -17,4 +17,12 @@
   vertical-align: middle;
   white-space: nowrap;
   word-wrap: normal;
+}
+
+.material-icon--space-before {
+  margin-left: 3px;
+}
+
+.material-icon--space-after {
+  margin-right: 3px;
 }


### PR DESCRIPTION
Adds styles for buttons. fixes #3 

There are also a few other things in this PR:
- I had to make a bunch of changes to the stories to add classes, etc.
- I've introduced two spacing classes for material icons
- I've renamed the `material-icons` class to `material-icon`, which is more semantically correct. This has been documented in the change tracking document.
- Note that `btn--orange` currently does not meet the WCAG contrast threshold. This has been documented in the Known Issues section.