### PR TITLE
Add styles for card component

### DIFF
--- a/stories/card/Card.stories.mdx
+++ b/stories/card/Card.stories.mdx
@@ -4,7 +4,7 @@ import * as stories from './Card.stories.js';
 <Meta
   title="Components/Cards"
   args={{ titleText: 'Guide to Processing Collections',
-    linkTarget: 'https://rockarch.org',
+    linkTarget: '#',
     bodyText: 'arrangement and description',
     footerText: 'Last updated Tuesday, Mar 31 2020 2:30 PM' }} />
 

--- a/stories/card/card.handlebars
+++ b/stories/card/card.handlebars
@@ -1,11 +1,13 @@
-<li class="card">
-  <div class="card__body">
-    <a class="card__title" href="{{linkTarget}}">{{titleText}}</a>
-    <p class="card__body-text">{{bodyText}}</p>
-  </div>
-  {{#if footerText}}
-  <div class="card__footer">
-    <p class="card__footer-text">{{footerText}}</p>
-  </div>
-  {{/if}}
-</li>
+<ul class="card-list">
+  <li class="card">
+    <div class="card__body">
+      <a class="card__title" href="{{linkTarget}}">{{titleText}}</a>
+      <p class="card__body-text">{{bodyText}}</p>
+    </div>
+    {{#if footerText}}
+    <div class="card__footer">
+      <p class="card__footer-text">{{footerText}}</p>
+    </div>
+    {{/if}}
+  </li>
+</ul>

--- a/stylesheets/abstracts/_mixins.scss
+++ b/stylesheets/abstracts/_mixins.scss
@@ -37,3 +37,58 @@
   outline: solid 2px $mortar-grey;
   outline-offset: 2px;
 }
+
+/**
+* Mixins for responsive media queries.
+**/
+@mixin md-up {
+  @media screen and (min-width: $break-md) { @content; }
+}
+
+@mixin lg-up {
+  @media screen and (min-width: $break-lg) { @content; }
+}
+
+/**
+* Shows element only on medium or larger screens
+**/
+@mixin show-on-md-up {
+  display: none;
+
+  @include md-up {
+    display: inherit;
+  }
+}
+
+/**
+* Hides element on medium or larger screens
+**/
+@mixin hide-on-md-up {
+  display: inherit;
+
+  @include md-up {
+    display: none;
+  }
+}
+
+/**
+* Shows element only on large screens
+**/
+@mixin show-on-lg-up {
+  display: none;
+
+  @include lg-up {
+    display: inherit;
+  }
+}
+
+/**
+* Hides element only on large screens
+**/
+@mixin hide-on-lg-up {
+  display: inherit;
+
+  @include lg-up {
+    display: none;
+  }
+}

--- a/stylesheets/abstracts/_variables.scss
+++ b/stylesheets/abstracts/_variables.scss
@@ -98,6 +98,8 @@ $break-lg: 1024px !default;
 ///   $base-url: 'http://cdn.example.com/assets/';
 $base-url: '/assets/' !default;
 
+$transition-default: all 0.2s ease;
+
 :export {
   black: $black;
   crustaorange: $crusta-orange;

--- a/stylesheets/components/_card.scss
+++ b/stylesheets/components/_card.scss
@@ -55,14 +55,13 @@
 /**
 * Base card styles
 * 1. Relative positioning is necessary in order to make entire card clickable.
-* 2. Only use transition if users have not declared a preference for reduced motion.
 **/
 .card {
   @include card-element-flex;
 
   align-items: flex-start;
   background-color: $desert-grey;
-  border-radius: 4px;
+  border-radius: $border-radius-default;
   box-shadow: 0 0 0 1px $silver-grey, 0 0 4px 0 lighten($silver-grey, 5%);
   box-sizing: border-box;
   margin-bottom: $gutters-default;
@@ -81,11 +80,9 @@
 
   &:hover,
   &:focus {
-    box-shadow: 0 0 0 2px $crusta-orange, 0 0 8px 2px lighten($silver-grey, 10%);
+    @include transition-default;
 
-    @media screen and (prefers-reduced-motion: no-preference) { /* 2 */
-      transition: $transition-default;
-    }
+    box-shadow: 0 0 0 2px $crusta-orange, 0 0 8px 2px lighten($silver-grey, 10%);
   }
 }
 

--- a/stylesheets/components/_card.scss
+++ b/stylesheets/components/_card.scss
@@ -44,7 +44,7 @@
 }
 
 /**
-* Styles the wrapper for the cards, which should be either a ul or an ol.
+* Styles the wrapper for the cards, which should be a ul element.
 **/
 .card-list {
   @include card-element-flex;

--- a/stylesheets/components/_card.scss
+++ b/stylesheets/components/_card.scss
@@ -1,0 +1,140 @@
+// -----------------------------------------------------------------------------
+// This file contains all styles related to the card component.
+// -----------------------------------------------------------------------------
+
+/**
+* Mixin for text used in cards
+**/
+@mixin card-text {
+  color: $night-grey;
+  font-family: $sans-serif-stack;
+  font-size: 15px;
+  font-weight: $font-weight-normal;
+  margin-top: 8px;
+
+  @include lg-up {
+    margin-top: 10px;
+  }
+}
+
+/**
+* Mixin for title text used in cards
+**/
+@mixin card-title-text {
+  @include card-text;
+
+  font-size: 18px;
+  font-weight: $font-weight-bold;
+  margin-top: 0;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    color: $night-grey;
+    text-decoration: none;
+  }
+}
+
+/**
+* Mixin for flex styles used in all card elements
+**/
+@mixin card-element-flex {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+/**
+* Styles the wrapper for the cards, which should be either a ul or an ol.
+**/
+.card-list {
+  @include card-element-flex;
+
+  padding: 0;
+}
+
+/**
+* Base card styles
+* 1. Relative positioning is necessary in order to make entire card clickable.
+* 2. Only use transition if users have not declared a preference for reduced motion.
+**/
+.card {
+  @include card-element-flex;
+
+  align-items: flex-start;
+  background-color: $desert-grey;
+  border-radius: 4px;
+  box-shadow: 0 0 0 1px $silver-grey, 0 0 4px 0 lighten($silver-grey, 5%);
+  box-sizing: border-box;
+  margin-bottom: $gutters-default;
+  padding: 26px 20px;
+  position: relative; /* 1 */
+
+  @include md-up {
+    min-height: 210px;
+    padding: 32px 20px;
+  }
+
+  @include lg-up {
+    min-height: 220px;
+    padding: 32px 26px;
+  }
+
+  &:hover,
+  &:focus {
+    box-shadow: 0 0 0 2px $crusta-orange, 0 0 8px 2px lighten($silver-grey, 10%);
+
+    @media screen and (prefers-reduced-motion: no-preference) { /* 2 */
+      transition: $transition-default;
+    }
+  }
+}
+
+/**
+* Styles the card body, which contains the title and body text.
+* 1. Pushes content to the top of the card body.
+**/
+.card__body {
+  @include card-element-flex;
+
+  align-self: flex-start; /* 1 */
+  width: 100%;
+}
+
+/**
+* Styles the card footer, which contains footer text.
+* 1. Pushes content to the bottom of the footer.
+**/
+.card__footer {
+  @include card-element-flex;
+
+  align-self: flex-end; /* 1 */
+  padding-top: 22px;
+  width: 100%;
+}
+
+/**
+* Styles for card titles.
+* 1. Creates a pseudo element which makes the entire card clickable.
+* 2. Ensures that the card title will always be on a line by itself.
+**/
+.card__title {
+  @include card-title-text;
+
+  width: 100%; /* 2 */
+  &::after { /* 1 */
+    bottom: 0;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+}
+
+.card__body-text {
+  @include card-text;
+}
+
+.card__footer-text {
+  @include card-text;
+}

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -26,6 +26,7 @@
 @import
   'components/button',
   'components/badge',
+  'components/card',
   'components/icon';
 
 // 6. Page-specific styles


### PR DESCRIPTION
Adds styles for card component. A couple of notes:
- The DIMES styles include CSS properties which set the width of the card. I have removed those here, since the number of cards in a row is likely to be a contextual decision.
- Because we don't have a `light-gray` equivalent, I've just used a calculation for those values (`box-shadow`)
- I've added very basic styles for a `card-list`. Curious what others think about this - does it make sense to consider the list an integral part of the component? The initial reason I did this was because Storybook was throwing an error because my `li` element wasn't contained in a `ul` or `ol`...

Fixes #57 