### PR TITLE
Add tableOfContents styles

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -9,7 +9,7 @@
   "rules": {
     "a11y/media-prefers-reduced-motion": true,
     "a11y/no-outline-none": true,
-    "a11y/selector-pseudo-class-focus": true,
+    "a11y/selector-pseudo-class-focus": null,
     "at-rule-no-unknown": null,
     "selector-class-pattern": [
       "^[a-z]([a-z0-9-]+)?(__([a-z0-9]+-?)+)?(--([a-z0-9]+-?)+){0,2}$",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -9,7 +9,6 @@
   "rules": {
     "a11y/media-prefers-reduced-motion": true,
     "a11y/no-outline-none": true,
-    "a11y/selector-pseudo-class-focus": null,
     "at-rule-no-unknown": null,
     "selector-class-pattern": [
       "^[a-z]([a-z0-9-]+)?(__([a-z0-9]+-?)+)?(--([a-z0-9]+-?)+){0,2}$",

--- a/stories/tableOfContents/TableOfContents.stories.js
+++ b/stories/tableOfContents/TableOfContents.stories.js
@@ -6,4 +6,4 @@ export const blue = (args) => TableOfContents({ class: 'toc--blue', ...args })
 
 export const orange = (args) => TableOfContents({ class: 'toc--orange', ...args })
 
-export const withTitle = (args) => TableOfContents({ class: 'toc--neutral', ...args })
+export const withTitle = (args) => TableOfContents({ class: 'toc--neutral', title: 'Digital Preservation Policy', ...args })

--- a/stories/tableOfContents/TableOfContents.stories.js
+++ b/stories/tableOfContents/TableOfContents.stories.js
@@ -1,9 +1,9 @@
 import TableOfContents from './tableOfContents.handlebars'
 
-export const colors = (args) => {
-  const componentColors = ['toc--neutral', 'toc--blue', 'toc--orange']
-  const tocs = componentColors.map(c => TableOfContents({ class: c, ...args })).join('')
-  return tocs
-}
+export const neutral = (args) => TableOfContents({ class: 'toc--neutral', ...args })
 
-export const withTitle = (args) => TableOfContents({ class: 'toc--neutral', title: 'Digital Preservation Policy', ...args })
+export const blue = (args) => TableOfContents({ class: 'toc--blue', ...args })
+
+export const orange = (args) => TableOfContents({ class: 'toc--orange', ...args })
+
+export const withTitle = (args) => TableOfContents({ class: 'toc--neutral', ...args })

--- a/stories/tableOfContents/TableOfContents.stories.mdx
+++ b/stories/tableOfContents/TableOfContents.stories.mdx
@@ -35,7 +35,11 @@ No related components.
 The table of contents comes in a variety of colors. Use the `toc--neutral`,
 `toc--blue` and `toc--orange` classes.
 
-<Story story={stories.colors} />
+<Story story={stories.neutral} />
+
+<Story story={stories.blue} />
+
+<Story story={stories.orange} />
 
 ## Adding a title
 

--- a/stories/tableOfContents/TableOfContents.stories.mdx
+++ b/stories/tableOfContents/TableOfContents.stories.mdx
@@ -29,7 +29,7 @@ No related components.
 
 ## Known issues
 
-No known issues.
+`toc--orange` does not meet WCAG requirements for color contrast.
 
 ## Colors
 The table of contents comes in a variety of colors. Use the `toc--neutral`,

--- a/stories/tableOfContents/TableOfContents.stories.mdx
+++ b/stories/tableOfContents/TableOfContents.stories.mdx
@@ -23,6 +23,9 @@ without having to scroll.
 
 Provide a `role=navigation` attribute to indicate the purpose of this element for assistive technology.
 
+Optionally use `class="active"` to indicate when a specific section of contents is visible on the page, if that
+functionality is built into the table of contents implementation.
+
 ## Related components
 
 No related components.
@@ -43,6 +46,6 @@ The table of contents comes in a variety of colors. Use the `toc--neutral`,
 
 ## Adding a title
 
-The table of contents can also have a title:
+The table of contents can also have one or more titles to separate sections:
 
 <Story story={stories.withTitle} />

--- a/stories/tableOfContents/listItems.json
+++ b/stories/tableOfContents/listItems.json
@@ -1,13 +1,13 @@
 [
-  {"text": "Purpose", "active": true},
-  {"text": "Objectives", "active": false},
-  {"text": "Mandate", "active": false},
-  {"text": "Scope", "active": false},
-  {"text": "Challenges", "active": false},
-  {"text": "Principles", "active": false},
-  {"text": "Categories of Commitment", "active": false},
-  {"text": "Frequency of Policy Review", "active": false},
-  {"text": "Roles and Responsibilities", "active": false},
-  {"text": "Appendix A: Glossary", "active": false},
-  {"text": "Appendix B: Sources Consulted", "active": false}
+  {"text": "Purpose"},
+  {"text": "Objectives"},
+  {"text": "Mandate"},
+  {"text": "Scope"},
+  {"text": "Challenges"},
+  {"text": "Principles"},
+  {"text": "Categories of Commitment"},
+  {"text": "Frequency of Policy Review"},
+  {"text": "Roles and Responsibilities"},
+  {"text": "Appendix A: Glossary"},
+  {"text": "Appendix B: Sources Consulted"}
 ]

--- a/stories/tableOfContents/listItems.json
+++ b/stories/tableOfContents/listItems.json
@@ -1,13 +1,13 @@
 [
-  {"text": "Purpose"},
-  {"text": "Objectives"},
-  {"text": "Mandate"},
-  {"text": "Scope"},
-  {"text": "Challenges"},
-  {"text": "Principles"},
-  {"text": "Categories of Commitment"},
-  {"text": "Frequency of Policy Review"},
-  {"text": "Roles and Responsibilities"},
-  {"text": "Appendix A: Glossary"},
-  {"text": "Appendix B: Sources Consulted"}
+  {"text": "Purpose", "active": true},
+  {"text": "Objectives", "active": false},
+  {"text": "Mandate", "active": false},
+  {"text": "Scope", "active": false},
+  {"text": "Challenges", "active": false},
+  {"text": "Principles", "active": false},
+  {"text": "Categories of Commitment", "active": false},
+  {"text": "Frequency of Policy Review", "active": false},
+  {"text": "Roles and Responsibilities", "active": false},
+  {"text": "Appendix A: Glossary", "active": false},
+  {"text": "Appendix B: Sources Consulted", "active": false}
 ]

--- a/stories/tableOfContents/tableOfContents.handlebars
+++ b/stories/tableOfContents/tableOfContents.handlebars
@@ -1,8 +1,8 @@
-<nav class="toc {{class}}" role="navigation" aria-label="{{ariaLabel}}">
-  {{#if title}}
-  <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
-  {{/if}}
+<nav class="toc {{class}}" role="navigation" aria-label="table of contents">
   <div class="toc__list">
+    {{#if title}}
+    <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
+    {{/if}}
     {{#each listItems}}
     <a class="toc__list-item" href="#{{this.text}}">{{this.text}}</a>
     {{/each}}

--- a/stories/tableOfContents/tableOfContents.handlebars
+++ b/stories/tableOfContents/tableOfContents.handlebars
@@ -1,4 +1,4 @@
-<nav class="toc {{class}}" role="navigation" aria-label="table of contents">
+<nav class="toc {{class}}" role="navigation" aria-label="{{ariaLabel}}">
   <div class="toc__list">
     {{#if title}}
     <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>

--- a/stories/tableOfContents/tableOfContents.handlebars
+++ b/stories/tableOfContents/tableOfContents.handlebars
@@ -1,10 +1,8 @@
 <nav class="toc {{class}}" role="navigation" aria-label="{{ariaLabel}}">
-  <div class="toc__list">
-    {{#if title}}
-    <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
-    {{/if}}
-    {{#each listItems}}
-    <a class="toc__list-item" href="#{{this.text}}">{{this.text}}</a>
-    {{/each}}
-  </div>
+  {{#if title}}
+  <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
+  {{/if}}
+  {{#each listItems}}
+  <a class="toc__list-item {{#if this.active}}active{{/if}}" href="#{{this.text}}">{{this.text}}</a>
+  {{/each}}
 </nav>

--- a/stories/tableOfContents/tableOfContents.handlebars
+++ b/stories/tableOfContents/tableOfContents.handlebars
@@ -4,7 +4,7 @@
   {{/if}}
   <div class="toc__list">
     {{#each listItems}}
-    <a class="toc__list-item {{#if this.active}}active{{/if}}" href="#{{this.text}}">{{this.text}}</a>
+    <a class="toc__list-item" href="#{{this.text}}">{{this.text}}</a>
     {{/each}}
   </div>
 </nav>

--- a/stylesheets/components/tableOfContents.scss
+++ b/stylesheets/components/tableOfContents.scss
@@ -1,0 +1,74 @@
+// -----------------------------------------------------------------------------
+// This file contains all styles related to the table of contents component
+// -----------------------------------------------------------------------------
+
+.rac-side-nav {
+  @media screen and (min-width: $break-md) {
+    display: flex;
+    margin-bottom: 60px;
+    position: sticky;
+    top: 60px;
+  }
+}
+
+.side-nav {
+  background: $burnt-orange;
+  display: none;
+  min-height: 250px;
+  padding: 36px 20px;
+  position: absolute;
+  width: calc(50% - 60px);
+
+  @media screen and (min-width: $break-md) {
+    display: block;
+    position: unset;
+    width: 100%;
+  }
+
+  @media screen and (min-width: $break-lg) {
+    padding: 36px 25px;
+
+    a {
+      font-size: 14px;
+      line-height: 18px;
+    }
+  }
+}
+
+.side-nav a {
+  color: $pure-white;
+  display: block;
+  font-family: $sans-serif-stack;
+  font-size: 14px;
+  font-weight: 900;
+  line-height: 17px;
+  list-style: none;
+  text-align: left;
+  width: 100%;
+
+  &:focus {
+    outline: 2px solid $pure-white;
+    text-decoration: none;
+  }
+
+  &:hover {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  &:not(:last-child) {
+    margin-bottom: 20px;
+  }
+}
+
+.rac-orange-button {
+  @include grid-column(12);
+
+  margin-bottom: 28px;
+  margin-left: 0;
+  margin-top: -52px;
+
+  @media screen and (min-width: $break-md) {
+    display: none;
+  }
+}

--- a/stylesheets/components/tableOfContents.scss
+++ b/stylesheets/components/tableOfContents.scss
@@ -2,12 +2,19 @@
 // This file contains all styles related to the table of contents component
 // -----------------------------------------------------------------------------
 
+/**
+* Styles for table of contents navigation
+**/
 .toc {
   margin-bottom: 60px;
   position: sticky;
   top: 60px;
 }
 
+/**
+* Styles for the group of table of contents items, including the title
+* 1. Indicates when a table of contents link is active
+**/
 .toc__list {
   min-height: 250px;
   padding: 36px 20px;
@@ -18,10 +25,14 @@
   }
 
   a:active {
-    @include focus-default;
+    @include focus-default; /* 1 */
   }
 }
 
+/**
+* Styles for the the contents links, including the title
+* 1. Creates more vertical space between items on large screens
+**/
 .toc__title,
 .toc__list-item {
   display: block;
@@ -32,10 +43,13 @@
   width: 100%;
 
   @include lg-up {
-    line-height: 18px;
+    line-height: 18px; /* 1 */
   }
 }
 
+/**
+* Styles for table of contents title. Font size and weight are the same as an h2 element
+**/
 .toc__title {
   font-size: 21px;
   font-weight: $font-weight-bold;
@@ -57,6 +71,10 @@
   cursor: pointer;
 }
 
+/**
+* Styles to create three table of contents color options
+* 1. Changes the default focus style outline color to be visible on the orange background
+**/
 .toc--neutral {
   background-color: $desert-grey;
 
@@ -85,6 +103,6 @@
 
   &:active,
   &:focus {
-    outline-color: $white;
+    outline-color: $white; /* 1 */
   }
 }

--- a/stylesheets/components/tableOfContents.scss
+++ b/stylesheets/components/tableOfContents.scss
@@ -37,14 +37,9 @@
 .toc__list-item {
   display: block;
   font-family: $sans-serif-stack;
-  line-height: 17px;
   text-align: left;
   text-decoration: none;
   width: 100%;
-
-  @include lg-up {
-    line-height: 18px; /* 1 */
-  }
 }
 
 /**
@@ -59,7 +54,12 @@
 .toc__list-item {
   font-size: 14px;
   font-weight: $font-weight-heavy;
+  line-height: 17px;
   list-style: none;
+
+  @include lg-up {
+    line-height: 18px; /* 1 */
+  }
 
   &:not(:last-child) {
     margin-bottom: 20px;

--- a/stylesheets/components/tableOfContents.scss
+++ b/stylesheets/components/tableOfContents.scss
@@ -2,58 +2,47 @@
 // This file contains all styles related to the table of contents component
 // -----------------------------------------------------------------------------
 
-.rac-side-nav {
-  @media screen and (min-width: $break-md) {
-    display: flex;
-    margin-bottom: 60px;
-    position: sticky;
-    top: 60px;
-  }
+.toc {
+  display: flex;
+  margin-bottom: 60px;
+  position: sticky;
+  top: 60px;
 }
 
-.side-nav {
-  background: $burnt-orange;
-  display: none;
+.toc__list {
+  display: block;
   min-height: 250px;
   padding: 36px 20px;
-  position: absolute;
-  width: calc(50% - 60px);
+  width: 100%;
 
-  @media screen and (min-width: $break-md) {
-    display: block;
-    position: unset;
-    width: 100%;
-  }
-
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     padding: 36px 25px;
-
-    a {
-      font-size: 14px;
-      line-height: 18px;
-    }
   }
 }
 
-.side-nav a {
-  color: $pure-white;
+.toc__list-item {
   display: block;
   font-family: $sans-serif-stack;
   font-size: 14px;
-  font-weight: 900;
+  font-weight: $font-weight-heavy;
   line-height: 17px;
   list-style: none;
   text-align: left;
+  text-decoration: none;
   width: 100%;
 
-  &:focus {
-    outline: 2px solid $pure-white;
-    text-decoration: none;
+  @include lg-up {
+    line-height: 18px;
   }
 
   &:hover {
     cursor: pointer;
-    text-decoration: none;
+    text-decoration: underline;
+  }
+
+  &:active,
+  &:focus {
+    @include focus-default;
   }
 
   &:not(:last-child) {
@@ -61,14 +50,31 @@
   }
 }
 
-.rac-orange-button {
-  @include grid-column(12);
+.toc--neutral {
+  background-color: $desert-grey;
 
-  margin-bottom: 28px;
-  margin-left: 0;
-  margin-top: -52px;
+  .toc__list-item {
+    color: $night-grey;
+  }
+}
 
-  @media screen and (min-width: $break-md) {
-    display: none;
+.toc--blue {
+  background-color: $solitude-blue;
+
+  .toc__list-item {
+    color: $regal-blue;
+  }
+}
+
+.toc--orange {
+  background-color: $flame-orange;
+}
+
+.toc--orange .toc__list-item {
+  color: $white;
+
+  &:active,
+  &:focus {
+    outline-color: $white;
   }
 }

--- a/stylesheets/components/tableOfContents.scss
+++ b/stylesheets/components/tableOfContents.scss
@@ -5,39 +5,33 @@
 /**
 * Styles for table of contents navigation
 * 1. Keeps table of contents visible on the page while scrolling
+* 2. When site enables functionality to track visible sections of page, shows focus on toc link
 **/
 .toc {
   margin-bottom: 60px;
+  min-height: 250px;
+  padding: 36px 20px 16px;
   position: sticky; /* 1 */
   top: 60px;
   width: 100%;
-}
-
-/**
-* Styles for the group of table of contents items, including the title
-* 1. Indicates when a table of contents link is active
-**/
-.toc__list {
-  min-height: 250px;
-  padding: 36px 20px;
 
   @include lg-up {
-    padding: 36px 25px;
+    padding: 36px 20px 16px;
   }
 
-  a:active {
-    @include focus-default; /* 1 */
+  .active {
+    @include focus-default; /* 2 */
   }
 }
 
 /**
 * Styles for the the contents links, including the title
-* 1. Creates more vertical space between items on large screens
 **/
 .toc__title,
 .toc__list-item {
   display: block;
   font-family: $sans-serif-stack;
+  margin: 0 0 20px;
   text-align: left;
   text-decoration: none;
   width: 100%;
@@ -45,11 +39,11 @@
 
 /**
 * Styles for table of contents title. Font size and weight are the same as an h2 element
+* 1. Creates more vertical space between items on large screens
 **/
 .toc__title {
   font-size: 21px;
   font-weight: $font-weight-bold;
-  margin: 0 0 20px;
 }
 
 .toc__list-item {
@@ -61,10 +55,6 @@
   @include lg-up {
     line-height: 18px; /* 1 */
   }
-
-  &:not(:last-child) {
-    margin-bottom: 20px;
-  }
 }
 
 .toc__list-item :hover,
@@ -74,7 +64,7 @@
 
 /**
 * Styles to create three table of contents color options
-* 1. Changes the default focus style outline color to be visible on the orange background
+* 1. Changes outline color to be visible on the orange background
 **/
 .toc--neutral {
   background-color: $desert-grey;
@@ -96,13 +86,16 @@
 
 .toc--orange {
   background-color: $flame-orange;
+
+  .active {
+    outline-color: $white; /* 1 */
+  }
 }
 
 .toc--orange .toc__list-item,
 .toc--orange .toc__title {
   color: $white;
 
-  &:active,
   &:focus {
     outline-color: $white; /* 1 */
   }

--- a/stylesheets/components/tableOfContents.scss
+++ b/stylesheets/components/tableOfContents.scss
@@ -16,7 +16,7 @@
   width: 100%;
 
   @include lg-up {
-    padding: 36px 20px 16px;
+    padding: 36px 25px 16px;
   }
 
   .active {

--- a/stylesheets/components/tableOfContents.scss
+++ b/stylesheets/components/tableOfContents.scss
@@ -4,11 +4,13 @@
 
 /**
 * Styles for table of contents navigation
+* 1. Keeps table of contents visible on the page while scrolling
 **/
 .toc {
   margin-bottom: 60px;
-  position: sticky;
+  position: sticky; /* 1 */
   top: 60px;
+  width: 100%;
 }
 
 /**
@@ -18,7 +20,6 @@
 .toc__list {
   min-height: 250px;
   padding: 36px 20px;
-  width: 100%;
 
   @include lg-up {
     padding: 36px 25px;

--- a/stylesheets/components/tableOfContents.scss
+++ b/stylesheets/components/tableOfContents.scss
@@ -3,14 +3,12 @@
 // -----------------------------------------------------------------------------
 
 .toc {
-  display: flex;
   margin-bottom: 60px;
   position: sticky;
   top: 60px;
 }
 
 .toc__list {
-  display: block;
   min-height: 250px;
   padding: 36px 20px;
   width: 100%;
@@ -18,15 +16,17 @@
   @include lg-up {
     padding: 36px 25px;
   }
+
+  a:active {
+    @include focus-default;
+  }
 }
 
+.toc__title,
 .toc__list-item {
   display: block;
   font-family: $sans-serif-stack;
-  font-size: 14px;
-  font-weight: $font-weight-heavy;
   line-height: 17px;
-  list-style: none;
   text-align: left;
   text-decoration: none;
   width: 100%;
@@ -34,26 +34,34 @@
   @include lg-up {
     line-height: 18px;
   }
+}
 
-  &:hover {
-    cursor: pointer;
-    text-decoration: underline;
-  }
+.toc__title {
+  font-size: 21px;
+  font-weight: $font-weight-bold;
+  margin: 0 0 20px;
+}
 
-  &:active,
-  &:focus {
-    @include focus-default;
-  }
+.toc__list-item {
+  font-size: 14px;
+  font-weight: $font-weight-heavy;
+  list-style: none;
 
   &:not(:last-child) {
     margin-bottom: 20px;
   }
 }
 
+.toc__list-item :hover,
+.toc__title :hover {
+  cursor: pointer;
+}
+
 .toc--neutral {
   background-color: $desert-grey;
 
-  .toc__list-item {
+  .toc__list-item,
+  .toc__title {
     color: $night-grey;
   }
 }
@@ -61,7 +69,8 @@
 .toc--blue {
   background-color: $solitude-blue;
 
-  .toc__list-item {
+  .toc__list-item,
+  .toc__title {
     color: $regal-blue;
   }
 }
@@ -70,7 +79,8 @@
   background-color: $flame-orange;
 }
 
-.toc--orange .toc__list-item {
+.toc--orange .toc__list-item,
+.toc--orange .toc__title {
   color: $white;
 
   &:active,

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -32,7 +32,7 @@
   'components/icon',
   'components/inputs',
   'components/pagination',
-  'components/social-icons';
+  'components/social-icons',
   'components/tableOfContents';
 
 // 6. Page-specific styles

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -29,7 +29,8 @@
   'components/button',
   'components/card',
   'components/icon',
-  'components/pagination';
+  'components/pagination',
+  'components/tableOfContents';
 
 // 6. Page-specific styles
 @import


### PR DESCRIPTION
Fixes #68 

Based on styles from rockarch.org. 

rockarch.org removes the table of contents display on small screens, where you can then access it using a button. From the html, it looks like we were looking to move away from that, or at least remove it from the component here.

Storybook includes 3 color versions and one with a title, which we don't have existing styles for, so I made some design decisions on those. I welcome feedback if others have a different vision.

I also removed the [selector-psuedo-class-focus](https://github.com/YozhikM/stylelint-a11y/blob/master/src/rules/selector-pseudo-class-focus/README.md) rule from stylelint/a11y because it wasn't letting me adjust hover styles without also applying a focus style (even though there were existing focus styles that had already been defined in _base.scss).