### PR TITLE
Add skip link styles

### DIFF
--- a/stories/skipLink/SkipLink.stories.js
+++ b/stories/skipLink/SkipLink.stories.js
@@ -1,7 +1,3 @@
 import SkipLink from './skipLink.handlebars'
 
-export const colors = (args) => {
-  const componentColors = ['skip-link--blue', 'skip-link--orange']
-  const skipLinks = componentColors.map(c => SkipLink({ class: c, ...args })).join('')
-  return skipLinks
-}
+export const basic = (args) => SkipLink({ ...args })

--- a/stories/skipLink/SkipLink.stories.mdx
+++ b/stories/skipLink/SkipLink.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
+import { Meta, Story } from '@storybook/addon-docs/blocks';
 import * as stories from './SkipLink.stories.js';
 
 <Meta

--- a/stories/skipLink/SkipLink.stories.mdx
+++ b/stories/skipLink/SkipLink.stories.mdx
@@ -21,8 +21,8 @@ to main content” link on every page as the first item within the `body` elemen
 
 ## Best practices
 
-Use the `visually-hidden` class to hide the skip link until it receives user focus.
-The skip link target may vary depending on your HTML structure.
+The skip link should remain hidden until it receives user focus. The skip link
+target may vary depending on your HTML structure.
 
 ## Related components
 
@@ -32,7 +32,4 @@ No related components.
 
 The color flame-orange does not meet WCAG contrast requirements against the current background.
 
-## Colors
-Skip links can be either blue or orange. Use the `skip-link--blue` and `skip-link--orange` classes.
-
-<Story story={stories.colors} />
+<Story story={stories.basic} />

--- a/stories/skipLink/SkipLink.stories.mdx
+++ b/stories/skipLink/SkipLink.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
 import * as stories from './SkipLink.stories.js';
 
 <Meta
@@ -32,4 +32,6 @@ No related components.
 
 The color flame-orange does not meet WCAG contrast requirements against the current background.
 
-<Story story={stories.basic} />
+<Canvas>
+  <Story story={stories.basic} height='100px'/>
+</Canvas>

--- a/stories/skipLink/SkipLink.stories.mdx
+++ b/stories/skipLink/SkipLink.stories.mdx
@@ -30,7 +30,7 @@ No related components.
 
 ## Known issues
 
-No known issues.
+The color flame-orange does not meet WCAG contrast requirements against the current background.
 
 ## Colors
 Skip links can be either blue or orange. Use the `skip-link--blue` and `skip-link--orange` classes.

--- a/stories/skipLink/SkipLink.stories.mdx
+++ b/stories/skipLink/SkipLink.stories.mdx
@@ -5,7 +5,7 @@ import * as stories from './SkipLink.stories.js';
   title="Components/Skip Link"
   args={{
     text: 'Skip to main content',
-    hidden: false
+    shown: false
   }} />
 
 # Skip Link
@@ -24,6 +24,10 @@ to main content” link on every page as the first item within the `body` elemen
 The skip link should remain hidden until it receives user focus. The skip link
 target may vary depending on your HTML structure.
 
+In order to demonstrate the appearance of the skip link, inline styles are added
+to the HTML when the component is toggled to "shown". These styles _should not_
+be copied when this component is added to web properties.
+
 ## Related components
 
 No related components.
@@ -32,6 +36,7 @@ No related components.
 
 The color flame-orange does not meet WCAG contrast requirements against the current background.
 
-<Canvas>
-  <Story story={stories.basic} height='100px'/>
-</Canvas>
+The skip link component is hidden by default. To see what it looks like, switch
+to the Canvas tab and toggle the "shown" switch.
+
+<Story story={stories.basic} height='200px' position='relative'/>

--- a/stories/skipLink/SkipLink.stories.mdx
+++ b/stories/skipLink/SkipLink.stories.mdx
@@ -34,7 +34,9 @@ No related components.
 
 ## Known issues
 
-The color flame-orange does not meet WCAG contrast requirements against the current background.
+Does not meet WCAG requirements for color contrast.
+
+## Default implementation
 
 The skip link component is hidden by default. To see what it looks like, switch
 to the Canvas tab and toggle the "shown" switch.

--- a/stories/skipLink/skipLink.handlebars
+++ b/stories/skipLink/skipLink.handlebars
@@ -1,1 +1,7 @@
-<a href="#main" class="skip-link"{{#if hidden}} visually-hidden{{/if}}>{{text}}</a>
+<a href="#main" class="skip-link"{{#if shown}} style="clip: auto;
+  height: auto;
+  overflow: auto;
+  position: absolute;
+  width: auto;
+  z-index: 1000;"{{/if}}
+>{{text}}</a>

--- a/stories/skipLink/skipLink.handlebars
+++ b/stories/skipLink/skipLink.handlebars
@@ -1,1 +1,1 @@
-<a href="#main" class="skip-link">{{text}}</a>
+<a href="#main" class="skip-link"{{#if hidden}} visually-hidden{{/if}}>{{text}}</a>

--- a/stories/skipLink/skipLink.handlebars
+++ b/stories/skipLink/skipLink.handlebars
@@ -1,1 +1,1 @@
-<a href="#main" class="skip-link visually-hidden">{{text}}</a>
+<a href="#main" class="skip-link">{{text}}</a>

--- a/stories/skipLink/skipLink.handlebars
+++ b/stories/skipLink/skipLink.handlebars
@@ -1,1 +1,1 @@
-<a href="#main" class="skip-link {{class}}{{#if hidden}} visually-hidden{{/if}}">{{text}}</a>
+<a href="#main" class="skip-link visually-hidden">{{text}}</a>

--- a/stylesheets/components/_skip-link.scss
+++ b/stylesheets/components/_skip-link.scss
@@ -11,9 +11,11 @@
   font-family: $sans-serif-stack;
   font-size: 18px;
   font-weight: $font-weight-bold;
+  left: 80px;
   padding: 15px 20px 18px;
   position: absolute;
   text-align: center;
+  top: 60px;
 
   &:focus {
     color: $desert-grey;

--- a/stylesheets/components/_skip-link.scss
+++ b/stylesheets/components/_skip-link.scss
@@ -24,7 +24,7 @@
   &:focus {
     @include show-on-focus;
 
-    color: inherit; /* 1 */
+    color: $desert-grey; /* 1 */
     text-decoration: underline; /* 1 */
   }
 

--- a/stylesheets/components/_skip-link.scss
+++ b/stylesheets/components/_skip-link.scss
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------------
+// This file contains all styles related to the skip-link component
+// -----------------------------------------------------------------------------
+
+/**
+ * Class that defines the style for skipLink elements.
+**/
+.skip-link {
+  background: $flame-orange;
+  color: $desert-grey;
+  font-family: $sans-serif-stack;
+  font-size: 18px;
+  font-weight: $font-weight-bold;
+  padding: 15px 20px 18px;
+  position: absolute;
+  text-align: center;
+
+  &:focus {
+    color: $desert-grey;
+  }
+}

--- a/stylesheets/components/_skip-link.scss
+++ b/stylesheets/components/_skip-link.scss
@@ -3,26 +3,40 @@
 // -----------------------------------------------------------------------------
 
 /**
- * Class that defines the style for skipLink elements.
+ * Skip link styles mixin. Allows users to position the skip link as desired
+ * with $left and $top variables.
+ * 1. Overrides for default link styling.
 **/
-.skip-link {
+@mixin skip-link($left: 0, $top: 0) {
+  @include visually-hidden;
+
   background: $flame-orange;
   color: $desert-grey;
   font-family: $sans-serif-stack;
   font-size: 18px;
   font-weight: $font-weight-bold;
-  left: 80px;
+  left: $left;
   padding: 15px 20px 18px;
   position: absolute;
   text-align: center;
-  top: 60px;
-
-  &:hover {
-    background-color: inherit;
-    color: $desert-grey;
-  }
+  top: $top;
 
   &:focus {
-    color: $desert-grey;
+    @include show-on-focus;
+
+    color: inherit; /* 1 */
+    text-decoration: underline; /* 1 */
   }
+
+  &:hover {
+    color: $desert-grey; /* 1 */
+    text-decoration: none; /* 1 */
+  }
+}
+
+/**
+ * Class that uses the default skip link styles.
+**/
+.skip-link {
+  @include skip-link;
 }

--- a/stylesheets/components/_skip-link.scss
+++ b/stylesheets/components/_skip-link.scss
@@ -17,6 +17,11 @@
   text-align: center;
   top: 60px;
 
+  &:hover {
+    background-color: inherit;
+    color: $desert-grey;
+  }
+
   &:focus {
     color: $desert-grey;
   }

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -32,7 +32,8 @@
   'components/icon',
   'components/inputs',
   'components/pagination',
-  'components/social-icons';
+  'components/social-icons',
+  'components/skip-link';
 
 // 6. Page-specific styles
 @import


### PR DESCRIPTION
Adds the basic styles for skipLinks.

The visually-hidden portion has not been enabled in storybook. 

There was some conversation around this in regards to React. Should we enable it in the storybook handlebars here?

@HaSistrunk @helrond @bonniegee ?