### PR TITLE
Clean up transition-default

### DIFF
--- a/stylesheets/abstracts/_mixins.scss
+++ b/stylesheets/abstracts/_mixins.scss
@@ -43,7 +43,7 @@
 **/
 @mixin transition-default {
   @media screen and (prefers-reduced-motion: no-preference) {
-    transition: all 0.2s ease;
+    transition: $transition-default;
   }
 }
 

--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -46,6 +46,8 @@ a {
   text-decoration: underline;
 
   @include on-event {
+    @include transition-default;
+
     color: $crusta-orange; /* 1 */
     cursor: pointer; /* 2 */
     text-decoration: none; /* 3 */

--- a/stylesheets/components/_minimap.scss
+++ b/stylesheets/components/_minimap.scss
@@ -35,8 +35,6 @@ $grid-col-count: 20;
   text-decoration: none;
 
   @include on-event {
-    @include transition-default;
-
     border: 2px solid darken($color, 22%);
     color: $color;
     outline: none;

--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -226,6 +226,8 @@
 * 2. Positions this element underneath the border-bottom of the nav__btn--dropdown.
 **/
 .nav__list--dropdown {
+  @include transition-default;
+
   background: $maroon-brown;
   padding: 22px 0 0;
   position: static;
@@ -284,10 +286,6 @@
   border: 0;
   margin-left: auto; /* 1 */
   margin-right: 10px; /* 2 */
-
-  &:hover {
-    @include transition-default;
-  }
 
   &:focus {
     outline-offset: 0; /* 3 */

--- a/stylesheets/components/_skip-link.scss
+++ b/stylesheets/components/_skip-link.scss
@@ -30,7 +30,6 @@
 
   &:hover {
     color: $desert-grey; /* 1 */
-    text-decoration: none; /* 1 */
   }
 }
 

--- a/stylesheets/components/search-form.scss
+++ b/stylesheets/components/search-form.scss
@@ -74,7 +74,7 @@
   display: none; /* 2 */
   position: relative;
 
-  @media screen and (min-width: $break-lg) {
+  @include lg-up {
     display: inline-block; /* 2 */
   }
 

--- a/stylesheets/layout/_footer.scss
+++ b/stylesheets/layout/_footer.scss
@@ -32,9 +32,6 @@
 @mixin footer-primary-link {
   @include footer-primary-text;
 
-  font-weight: $font-weight-normal;
-  text-decoration: underline;
-
   @media screen and (prefers-reduced-motion: no-preference) {
     &:hover,
     &:focus {
@@ -58,8 +55,6 @@
 **/
 @mixin footer-secondary-link {
   @include footer-secondary-text;
-
-  text-decoration: underline;
 
   @media screen and (prefers-reduced-motion: no-preference) {
     &:hover,

--- a/stylesheets/layout/_footer.scss
+++ b/stylesheets/layout/_footer.scss
@@ -32,12 +32,9 @@
 @mixin footer-primary-link {
   @include footer-primary-text;
 
-  @media screen and (prefers-reduced-motion: no-preference) {
-    &:hover,
-    &:focus {
-      color: $flame-orange;
-      transition: $transition-default;
-    }
+  &:hover,
+  &:focus {
+    color: $flame-orange;
   }
 }
 
@@ -56,13 +53,9 @@
 @mixin footer-secondary-link {
   @include footer-secondary-text;
 
-  @media screen and (prefers-reduced-motion: no-preference) {
-    &:hover,
-    &:focus {
-      color: $desert-grey;
-      text-decoration: none;
-      transition: $transition-default;
-    }
+  &:hover,
+  &:focus {
+    color: $desert-grey;
   }
 }
 


### PR DESCRIPTION
Fixes issue #104 

- Applies `transition-default` mixin to all link hover, focus, and active styles in `typography.scss` and removes the redundant individual application of that style where necessary in components with links.
- Adds the `transition-default` mixin to nav dropdowns to match the existing pattern for dropdowns in the `.dropdown__list` class.
- Removes `prefers-reduced-motion` media query from footer layout styles because that is already part of the `transition-default` styles (linting requires it in the social media component for svgs).
- Also cleans up `text-decoration` styles to align with the default link styles (underlined by default, remove underline on hover etc.)