### PR TITLE
Debug Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: node_js
 node_js:
   - "lts/*"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint"
   ],
   "scripts": {
-    "start": "react-scripts start --openssl-legacy-provider", //Fix because Node version 17 and above supports OpenSSL version 3 which doesn't enable the MD4 algorithm to create file hashes, and Webpack 4 requires MD4.
+    "start": "react-scripts start --openssl-legacy-provider",
     "compile": "sass stylesheets/main.scss dist/main.min.css --no-source-map --style=compressed && postcss dist/main.min.css --replace --use autoprefixer",
     "lint": "npx stylelint 'stylesheets/**/*.scss'",
     "lint-fix": "npx stylelint 'stylesheets/**/*.scss' --fix",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint"
   ],
   "scripts": {
+    "start": "react-scripts start --openssl-legacy-provider", //Fix because Node version 17 and above supports OpenSSL version 3 which doesn't enable the MD4 algorithm to create file hashes, and Webpack 4 requires MD4.
     "compile": "sass stylesheets/main.scss dist/main.min.css --no-source-map --style=compressed && postcss dist/main.min.css --replace --use autoprefixer",
     "lint": "npx stylelint 'stylesheets/**/*.scss'",
     "lint-fix": "npx stylelint 'stylesheets/**/*.scss' --fix",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,11 @@
     "lint"
   ],
   "scripts": {
-    "start": "react-scripts start --openssl-legacy-provider",
     "compile": "sass stylesheets/main.scss dist/main.min.css --no-source-map --style=compressed && postcss dist/main.min.css --replace --use autoprefixer",
     "lint": "npx stylelint 'stylesheets/**/*.scss'",
     "lint-fix": "npx stylelint 'stylesheets/**/*.scss' --fix",
     "test": "jest --testRegex test_ --env=node --passWithNoTests",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "lint": "npx stylelint 'stylesheets/**/*.scss'",
     "lint-fix": "npx stylelint 'stylesheets/**/*.scss' --fix",
     "test": "jest --testRegex test_ --env=node --passWithNoTests",
-    "storybook": "NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
+    "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook"
   },
   "browserslist": [
     "> 2%"


### PR DESCRIPTION
The Travis build was failing because versions of Node > 17 started supporting OpenSSL version 3, but Webpack 4 (used by Storybook) uses the MD4 algorithm to create file hashes and MD4 is not enabled in OpenSSL version 3. The options to fix this appear to be:

1. Update Storybook to [use Webpack 5](https://storybook.js.org/docs/react/builders/webpack#webpack-5)
2. Upgrade Storybook to [version 7](https://github.com/storybookjs/storybook/issues/20482) (but v.7 was JUST released and is still in beta, so I recommend we wait, particularly because it will require a few other changes to our Storybook implementation).
3. Add `NODE_OPTIONS=--openssl-legacy-provider` to the `storybook` and `storybook-build` scripts in `package.json` as discussed in [this GitHub issue](https://github.com/storybookjs/storybook/issues/20482), which I have done here as a temporary fix before we move to Storybook 7.