### PR TITLE
Adjust card, checkbox, and header styles and correct typography element styles

### DIFF
--- a/stories/card/Card.stories.mdx
+++ b/stories/card/Card.stories.mdx
@@ -31,6 +31,21 @@ No related components.
 No known issues.
 
 ## Default implementation
+The number of card columns can be specified in local CSS using media queries,
+with the base styles providing one column that takes up the full width of its container.
+For example, for 4 card columns on large screens and 3 columns on medium screens, use:
+```
+.card-list {
+  @include md-up {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @include lg-up {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+```
+
 By default, cards have a body and a footer.
 
 <Story story={stories.basic} />

--- a/stories/card/card.handlebars
+++ b/stories/card/card.handlebars
@@ -1,4 +1,4 @@
-<ul class="card-list">
+<ul class="card-list list--unstyled">
   <li class="card">
     <div class="card__body">
       <a class="card__title" href="{{linkTarget}}">{{titleText}}</a>

--- a/stories/textAreaInputs/TextAreaInputs.stories.js
+++ b/stories/textAreaInputs/TextAreaInputs.stories.js
@@ -6,6 +6,6 @@ export const required = (args) => TextareaInput({ ...args, required: true })
 
 export const hideLabel = (args) => TextareaInput({ ...args, hideLabel: true })
 
-export const hideHelpText = (args) => TextareaInput({ ...args, hideHelpText: true })
+export const helpText = (args) => TextareaInput({ ...args, helpText: true })
 
 export const withError = (args) => TextareaInput({ ...args, invalid: true })

--- a/stories/textAreaInputs/TextAreaInputs.stories.js
+++ b/stories/textAreaInputs/TextAreaInputs.stories.js
@@ -6,4 +6,6 @@ export const required = (args) => TextareaInput({ ...args, required: true })
 
 export const hideLabel = (args) => TextareaInput({ ...args, hideLabel: true })
 
+export const hideHelpText = (args) => TextareaInput({ ...args, hideHelpText: true })
+
 export const withError = (args) => TextareaInput({ ...args, invalid: true })

--- a/stories/textAreaInputs/TextareaInputs.stories.mdx
+++ b/stories/textAreaInputs/TextareaInputs.stories.mdx
@@ -47,6 +47,10 @@ No known issues.
 
 <Story story={stories.required} />
 
+## Help text
+
+<Story story={stories.hideHelpText} />
+
 ## Displaying errors
 
 <Story story={stories.withError} />

--- a/stories/textAreaInputs/TextareaInputs.stories.mdx
+++ b/stories/textAreaInputs/TextareaInputs.stories.mdx
@@ -49,7 +49,7 @@ No known issues.
 
 ## Help text
 
-<Story story={stories.hideHelpText} />
+<Story story={stories.helpText} />
 
 ## Displaying errors
 

--- a/stories/textAreaInputs/textareaInputs.handlebars
+++ b/stories/textAreaInputs/textareaInputs.handlebars
@@ -1,3 +1,4 @@
 <label for="{{name}}" {{#if hideLabel}}class="visually-hidden"{{/if}}>Message{{#if required}} *{{/if}}</label>
 <textarea name="{{name}}" id="{{name}}" rows="5"{{#if invalid}}class="is-invalid" aria-invalid="true" aria-describedby="{{name}}-error"{{/if}}{{#if required}} required{{/if}}></textarea>
+<p {{#if hideHelpText}} class="visually-hidden"{{/if}} class="input__help-text">255 characters minimum.</p>
 {{#if invalid}}<div id="{{name}}-error" class="input__error">This message must be shorter than 255 characters.</div>{{/if}}

--- a/stories/textAreaInputs/textareaInputs.handlebars
+++ b/stories/textAreaInputs/textareaInputs.handlebars
@@ -1,4 +1,4 @@
 <label for="{{name}}" {{#if hideLabel}}class="visually-hidden"{{/if}}>Message{{#if required}} *{{/if}}</label>
 <textarea name="{{name}}" id="{{name}}" rows="5"{{#if invalid}}class="is-invalid" aria-invalid="true" aria-describedby="{{name}}-error"{{/if}}{{#if required}} required{{/if}}></textarea>
-<p {{#if hideHelpText}} class="visually-hidden"{{/if}} class="input__help-text">255 characters minimum.</p>
+{{#if helpText}}<p class="input__help-text">255 characters minimum.</p>{{/if}}
 {{#if invalid}}<div id="{{name}}-error" class="input__error">This message must be shorter than 255 characters.</div>{{/if}}

--- a/stories/textInputs/textInput.handlebars
+++ b/stories/textInputs/textInput.handlebars
@@ -1,3 +1,5 @@
 <label for="{{name}}" {{#if hideLabel}}class="visually-hidden"{{/if}}>{{label}}{{#if required}} *{{/if}}</label>
 <input name="{{name}}"{{#if invalid}} class="is-invalid"{{/if}} type="text" id="{{name}}"{{#if invalid}} aria-invalid="true" aria-describedby="{{name}}-error"{{/if}}{{#if required}} required{{/if}}>
+{{#if helptext}}<div id="{{name}}-error" class="input__error">This field is required.</div>{{/if}}
 {{#if invalid}}<div id="{{name}}-error" class="input__error">This field is required.</div>{{/if}}
+

--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -37,6 +37,10 @@ body {
   font-size: 16px;
   font-weight: $font-weight-normal;
   line-height: inherit;
+}
+
+p,
+a {
   margin: 0 0 10px;
 }
 

--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -93,6 +93,11 @@ a {
 ul {
   font-family: $serif-stack;
   line-height: 23px;
+
+  @include lg-up {
+    font-size: 17px;
+    line-height: 24px;
+  }
 }
 
 /**

--- a/stylesheets/components/_card.scss
+++ b/stylesheets/components/_card.scss
@@ -13,7 +13,7 @@
   margin-top: 8px;
 
   @include lg-up {
-    margin-top: 10px;
+    margin: 10px 0;
   }
 }
 
@@ -45,11 +45,22 @@
 
 /**
 * Styles the wrapper for the cards, which should be a ul element.
+* 1. The number of card columns can be adjusted by screensize
+* using media queries.
 **/
 .card-list {
-  @include card-element-flex;
+  display: grid;
+  gap: $gutters-default;
+  grid-template-columns: 1fr;
+  margin: 0;
 
-  padding: 0;
+  // @include md-up {
+  //   grid-template-columns: repeat(3, 1fr); /* 1 */
+  // }
+
+  // @include lg-up {
+  //   grid-template-columns: repeat(4, 1fr); /* 1 */
+  //   }
 }
 
 /**
@@ -57,14 +68,9 @@
 * 1. Relative positioning is necessary in order to make entire card clickable.
 **/
 .card {
-  @include card-element-flex;
-
-  align-items: flex-start;
   background-color: $desert-grey;
   border-radius: $border-radius-default;
   box-shadow: 0 0 0 1px $silver-grey, 0 0 4px 0 lighten($silver-grey, 5%);
-  box-sizing: border-box;
-  margin-bottom: $gutters-default;
   padding: 26px 20px;
   position: relative; /* 1 */
 

--- a/stylesheets/components/_inputs.scss
+++ b/stylesheets/components/_inputs.scss
@@ -85,16 +85,6 @@ fieldset {
   outline: 2px solid $mortar-grey;
 }
 
-.checkbox:disabled + label::before {
-  background-color: $wan-white-grey;
-  border: 1px solid $mortar-grey;
-}
-
-.checkbox:disabled + label {
-  color: $mortar-grey;
-  cursor: not-allowed;
-}
-
 .checkbox:not(:checked),
 .checkbox:checked { /* 2 */
   left: -9999px;
@@ -189,6 +179,19 @@ fieldset {
   background-color: $white;
   border: 1px solid $night-grey;
   color: $night-grey;
+}
+
+/**
+* Styles for disabled checkboxes
+**/
+.checkbox:disabled + label::before {
+  background-color: $wan-white-grey;
+  border: 1px solid $mortar-grey;
+}
+
+.checkbox:disabled + label {
+  color: $mortar-grey;
+  cursor: not-allowed;
 }
 
 /**

--- a/stylesheets/components/_inputs.scss
+++ b/stylesheets/components/_inputs.scss
@@ -60,6 +60,13 @@ fieldset {
   padding: 10px;
 }
 
+.input__help-text {
+  color: $mortar-grey;
+  font-size: 13px;
+  font-style: italic;
+  margin: 0;
+}
+
 /**
 * Styles for checkboxes
 /**

--- a/stylesheets/components/_modal.scss
+++ b/stylesheets/components/_modal.scss
@@ -82,5 +82,5 @@ $modal-header-height: 52px;
 **/
 .modal__body {
   min-height: calc(80vh - $modal-header-height); /* 1 */
-  padding: 20px;
+  padding: 30px 20px;
 }

--- a/stylesheets/components/_social-icons.scss
+++ b/stylesheets/components/_social-icons.scss
@@ -11,6 +11,7 @@
   max-width: 250px;
 
   a {
+    margin: 0;
     text-decoration: none;
   }
 }

--- a/stylesheets/layout/_footer.scss
+++ b/stylesheets/layout/_footer.scss
@@ -123,7 +123,7 @@
 
 .footer-primary__social .social-icons {
   @include lg-up {
-    margin-left: auto;
+    margin: 0 0 18px auto;
   }
 }
 

--- a/stylesheets/layout/_footer.scss
+++ b/stylesheets/layout/_footer.scss
@@ -60,6 +60,16 @@
 }
 
 /**
+* Footer layout styles.
+* Ensures that there is never space between the bottom of the footer and the
+* bottom of the page.
+**/
+footer {
+  position: absolute;
+  width: 100%;
+}
+
+/**
 * Primary Footer styles.
 * 1. Insertion of a visual line break without causing screen readers to pause.
 **/

--- a/stylesheets/layout/_header.scss
+++ b/stylesheets/layout/_header.scss
@@ -38,7 +38,6 @@
 
 /**
 * Header sub-title mixin
-*1. Assumes title is always a link and underlines on event
 **/
 @mixin header-subtitle {
   @include header-text;
@@ -87,7 +86,7 @@
 * Styles for header branding section that includes title, subtitle, and/or image.
 **/
 .header__brand {
-  align-items: center;
+  align-content: center;
   display: flex;
   flex-wrap: wrap;
   margin-right: auto;
@@ -107,7 +106,7 @@
 .header__brand-subtitle {
   @include header-subtitle;
 
-  margin: 0;
+  margin: 4px 0 0;
 }
 
 /**

--- a/stylesheets/layout/_header.scss
+++ b/stylesheets/layout/_header.scss
@@ -101,7 +101,7 @@
 .header__brand-title {
   @include header-title;
 
-  margin-right: 10px;
+  margin: 0 10px 0 0;
 }
 
 .header__brand-subtitle {
@@ -116,6 +116,7 @@
 **/
 .header__brand-image {
   line-height: 0;
+  margin: 0;
 
   img {
     height: 56px; /* 1 */


### PR DESCRIPTION
- Updates card styles to use grid instead of flexbox and documents how to set the number of card columns. Our use of cards in sites is not agnostic about how many columns of cards there are, so this seemed like a better approach, although it requires media queries to be added in local styles...
- Corrects `p` and `a` styles to align with what we already have implemented in DIMES and rockarch.org
- Adds an `input__help-text` class for form inputs that matches the DIMES styles.
- Other small adjustments to header, footer, checkbox, and list styles to correct problems found during DIMES styles implementation.