### PR TITLE
Improve footer screen reader UX

### DIFF
--- a/stories/footer/footer.handlebars
+++ b/stories/footer/footer.handlebars
@@ -1,7 +1,9 @@
 <footer class="footer" role="contentinfo" style="position: relative">
   <div class="footer-primary">
     <div class="grid container">
-      <h2 class="footer-primary__title heading--dotted-border">Rockefeller <span class="line-break">Archive Center</span></h2>
+      <h2 aria-label="Rockefeller Archive Center" class="footer-primary__title heading--dotted-border">
+        <span aria-hidden="true">Rockefeller <br /> Archive Center</span>
+      </h2>
       <div class="footer-primary__address">
         <p class="footer-primary__text">15 Dayton Avenue<br>Sleepy Hollow, New York 10591</p>
         <p class="footer-primary__text">Phone: (914) 366-6300<br>Fax: (914) 631-6017<br>E-mail: <a class="footer-primary__link" href="mailto:archive@rockarch.org">archive@rockarch.org</a></p>

--- a/stylesheets/layout/_footer.scss
+++ b/stylesheets/layout/_footer.scss
@@ -81,10 +81,6 @@
   grid-column: 1 / span 12;
   margin: 60px 0 28px;
   padding-bottom: 0;
-
-  .line-break {
-    display: table; /* 1 */
-  }
 }
 
 .footer-primary__address,


### PR DESCRIPTION
Fixes #156 

Note that this is a breaking change for previous footer implementation because it removes the `.line-break` class.