### PR TITLE
Improve header and footer to work on sites with limited width

### DIFF
--- a/stories/footer/footer.handlebars
+++ b/stories/footer/footer.handlebars
@@ -1,39 +1,40 @@
 <footer class="footer" role="contentinfo" style="position: relative">
   <div class="footer-primary">
-    <div class="grid container">
-      <h2 aria-label="Rockefeller Archive Center" class="footer-primary__title heading--dotted-border">
-        <span aria-hidden="true">Rockefeller <br /> Archive Center</span>
-      </h2>
-      <div class="footer-primary__address">
-        <p class="footer-primary__text">15 Dayton Avenue<br>Sleepy Hollow, New York 10591</p>
-        <p class="footer-primary__text">Phone: (914) 366-6300<br>Fax: (914) 631-6017<br>E-mail: <a class="footer-primary__link" href="mailto:archive@rockarch.org">archive@rockarch.org</a></p>
-      </div>
-      <div class="footer-primary__reading-room">
-        <p class="footer-primary__text">Reading Room Hours:</p>
-        <p class="footer-primary__text">Monday-Friday<br>9:00 a.m. to 5:00 p.m.<br><a class="footer-primary__link" href="https://rockarch.org/collections/access-and-request-materials/">How to access and request materials</a>.</p><a
-          class="footer-primary__link" href="https://rockarch.org/collections/access-and-request-materials/holiday-schedule/">See holiday schedule</a>
-      </div>
-      <div class="footer-primary__social">
-        {{> ../socialIcons/socialIcons}}
-        <p class="footer-primary__text">
-          <a class="footer-primary__link footer-primary__policy-link" href="https://rockarch.org/about-us/accessibility/">Accessibility Statement</a>
-          <a class="footer-primary__link footer-primary__policy-link" href="https://rockarch.org/about-us/privacy-policy/">Privacy Policy</a>
-          <a class="footer-primary__link footer-primary__policy-link" href="https://docs.rockarch.org">RAC Policies</a>
-        </p>
-        <p class="footer-primary__text">Copyright © Rockefeller Archive Center. All rights reserved.</p>
+    <div class="wrapper">
+      <div class="grid container">
+        <h2 aria-label="Rockefeller Archive Center" class="footer-primary__title heading--dotted-border">
+          <span aria-hidden="true">Rockefeller <br /> Archive Center</span>
+        </h2>
+        <div class="footer-primary__address">
+          <p class="footer-primary__text">15 Dayton Avenue<br>Sleepy Hollow, New York 10591</p>
+          <p class="footer-primary__text">Phone: (914) 366-6300<br>Fax: (914) 631-6017<br>E-mail: <a class="footer-primary__link" href="mailto:archive@rockarch.org">archive@rockarch.org</a></p>
+        </div>
+        <div class="footer-primary__reading-room">
+          <p class="footer-primary__text">Reading Room Hours:</p>
+          <p class="footer-primary__text">Monday-Friday<br>9:00 a.m. to 5:00 p.m.<br><a class="footer-primary__link" href="https://rockarch.org/collections/access-and-request-materials/">How to access and request materials</a>.</p><a
+            class="footer-primary__link" href="https://rockarch.org/collections/access-and-request-materials/holiday-schedule/">See holiday schedule</a>
+        </div>
+        <div class="footer-primary__social">
+          {{> ../socialIcons/socialIcons}}
+          <p class="footer-primary__text">
+            <a class="footer-primary__link footer-primary__policy-link" href="https://rockarch.org/about-us/accessibility/">Accessibility Statement</a>
+            <a class="footer-primary__link footer-primary__policy-link" href="https://rockarch.org/about-us/privacy-policy/">Privacy Policy</a>
+            <a class="footer-primary__link footer-primary__policy-link" href="https://docs.rockarch.org">RAC Policies</a>
+          </p>
+          <p class="footer-primary__text">Copyright © Rockefeller Archive Center. All rights reserved.</p>
+        </div>
       </div>
     </div>
   </div>
   {{#if showSecondary}}
   <div class="footer-secondary">
-    <div class="grid">
+    <div class="grid container">
       <ul class="footer-secondary__list">
         <li class='footer-secondary__list-item'><a class='footer-secondary__link' href='https://docs.rockarch.org/argo-docs/'>Collections data API</a></li>
         <li class="footer-secondary__list-item"><a class="footer-secondary__link" href="https://docs.rockarch.org/archival-description-license/">Licensing for our descriptive metadata</a></li>
         <li class="footer-secondary__list-item"><a class="footer-secondary__link" href="https://github.com/RockefellerArchiveCenter/data/">Bulk data download</a></li>
         <li class="footer-secondary__list-item"><a class="footer-secondary__link" href="https://docs.rockarch.org/takedown-policy/">Take-down policy</a></li>
       </ul>
-    </div>
     </div>
   </div>
   {{/if}}

--- a/stories/header/header.handlebars
+++ b/stories/header/header.handlebars
@@ -1,34 +1,36 @@
 <header class="header {{class}}">
-  <div class="wrapper">
+  <div class="container">
+    <div class="wrapper">
 
-    {{#if withTextBrand}}
-      <div class="header__brand header__brand--text">
-        <a href="/" class="header__brand-title">{{brandTitle}}</a>
-        <p class="header__brand-subtitle">{{brandSubtitle}}</p>
-      </div>
-    {{/if}}
+      {{#if withTextBrand}}
+        <div class="header__brand header__brand--text">
+          <a href="/" class="header__brand-title">{{brandTitle}}</a>
+          <p class="header__brand-subtitle">{{brandSubtitle}}</p>
+        </div>
+      {{/if}}
 
-    {{#if withImageBrand}}
-      <div class="header__brand">
-        <a href="/" class="header__brand-image">
-          <img alt="Rockefeller Archive Center" src="{{logoUrl}}">
-        </a>
-      </div>
-    {{/if}}
+      {{#if withImageBrand}}
+        <div class="header__brand">
+          <a href="/" class="header__brand-image">
+            <img alt="Rockefeller Archive Center" src="{{logoUrl}}">
+          </a>
+        </div>
+      {{/if}}
 
-    {{#if withNavItems}}
-      {{> navItems}}
-    {{/if}}
+      {{#if withNavItems}}
+        {{> navItems}}
+      {{/if}}
 
-    {{#if withDropdownItems}}
-      {{> dropdownItems}}
-    {{/if}}
+      {{#if withDropdownItems}}
+        {{> dropdownItems}}
+      {{/if}}
 
-    {{#if withSocialIcons}}
-      <div class="header__social-icons">
-        {{> ../socialIcons/socialIcons}}
-      </div>
-    {{/if}}
+      {{#if withSocialIcons}}
+        <div class="header__social-icons">
+          {{> ../socialIcons/socialIcons}}
+        </div>
+      {{/if}}
 
+    </div>
   </div>
 </header>

--- a/stories/header/header.handlebars
+++ b/stories/header/header.handlebars
@@ -1,6 +1,6 @@
 <header class="header {{class}}">
-  <div class="container">
-    <div class="wrapper">
+  <div class="wrapper">
+    <div class="container flex">
 
       {{#if withTextBrand}}
         <div class="header__brand header__brand--text">

--- a/stylesheets/base/_helpers.scss
+++ b/stylesheets/base/_helpers.scss
@@ -38,6 +38,10 @@
   justify-content: center;
 }
 
+.flex {
+  display: flex;
+}
+
 /**
  * Hide text while making it readable for screen readers
  * 1. Needed in WebKit-based browsers because of an implementation bug;

--- a/stylesheets/layout/_footer.scss
+++ b/stylesheets/layout/_footer.scss
@@ -145,7 +145,6 @@
 .footer-secondary__list {
   grid-column: 1 / span 12;
   list-style: none;
-  margin-left: 15px;
   padding: 0;
 
   @include lg-up { text-align: right; }
@@ -158,4 +157,8 @@
     display: inline-block;
     padding-right: 28px;
   }
+}
+
+.footer-secondary__list-item:last-of-type {
+  padding-right: 0;
 }

--- a/stylesheets/layout/_header.scss
+++ b/stylesheets/layout/_header.scss
@@ -53,7 +53,6 @@
 
 .header {
   min-height: 60px;
-  padding: 0 15px;
   width: 100%;
 
   .wrapper {


### PR DESCRIPTION
Fixes #163 

Uses wrapper and container divs to center and contain header and footer layouts to work with sites that have a `max-width` set.

Also adds a `.flex` helper class.