### PR TITLE
Add layout and spacing documentation

### DIFF
--- a/stories/global/layout/GridLayout.stories.js
+++ b/stories/global/layout/GridLayout.stories.js
@@ -1,0 +1,3 @@
+import GridLayout from './gridLayout.handlebars'
+
+export const gridLayout = () => GridLayout()

--- a/stories/global/layout/Layout.stories.mdx
+++ b/stories/global/layout/Layout.stories.mdx
@@ -24,8 +24,8 @@ with  `justify-content: center;`
 
 ## Best practices
 
-Design for a responsive layout that includes small screens using a single-column
-layout. Use media queries as needed to adjust for medium screens and
+Design for a responsive layout by initially creating styles for small screens using a single-column
+layout. Then, enhance using media queries as needed to adjust for medium screens and
 large screens. You can add the SCSS mixins for media queries in local
 site styles along with the screen size breakpoint variables:
 ```

--- a/stories/global/layout/Layout.stories.mdx
+++ b/stories/global/layout/Layout.stories.mdx
@@ -1,0 +1,56 @@
+import { Meta, Story, Typeset } from '@storybook/addon-docs/blocks';
+import * as gridLayoutStories from './GridLayout.stories.js';
+
+<Meta title="Global/Layout" />
+
+# Layout
+Layout dictates how components appear on the page in relation to each
+other, including on different devices and screen sizes.
+
+## Usage
+Use [CSS Flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox),
+[CSS Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout), and the `float` property as needed to
+position components and set page areas. There are multiple page wrapper and layout helper classes to
+facilitate layout:
+
+- `container`: Sets a container elements with 15px margin gutters on either side of the
+container with a width of 100% minus the gutters.
+- `container--full-width`: Sets a container element to `width: 100%` with no gutters.
+- `wrapper`: Creates a flexbox wrapper (`display: flex`) that centers the content inside
+with  `justify-content: center;`
+- `flex`: Simply adds `display: flex` to an element.
+- `grid`: Creates a CSS Grid container with 12 columns that fill the container by applying
+  the styles `display: grid` and `grid-template-columns: repeat(12, 1fr)` to the element.
+
+## Best practices
+
+Design for a responsive layout that includes small screens using a single-column
+layout. Use media queries as needed to adjust for medium screens and
+large screens. You can add the SCSS mixins for media queries in local
+site styles along with the screen size breakpoint variables:
+```
+// Breakpoints map
+$break-md: 580px;
+$break-lg: 1024px;
+
+@mixin md-up {
+  @media screen and (min-width: $break-md) { @content; }
+}
+
+@mixin lg-up {
+  @media screen and (min-width: $break-lg) { @content; }
+}
+```
+There is no default maximum width set in the styles, but for sites that require a
+maximum width, use `max-width: 1440px`.
+
+## Known issues
+There are no known issues.
+
+## Implementing a 12-column grid
+Apply the `grid` class to a container to define 12 columns on the page, and then
+specify which/how many columns each child element should span using the `grid-column`
+property.
+
+<Story story={gridLayoutStories.gridLayout} />
+

--- a/stories/global/layout/gridLayout.handlebars
+++ b/stories/global/layout/gridLayout.handlebars
@@ -1,0 +1,26 @@
+
+<div class="grid">
+  <div class="p-10 mb-20" style="grid-column: 1 / span 12; background-color: #f6f6f6">
+  Content spans 12 columns by applying the <code>grid</code> class to the container
+  and the CSS Grid styles <code>grid-column: 1 / span 12</code> to the element.
+  </div>
+
+  <div class="p-10 mb-20" style="grid-column: 1 / span 6; background-color: #f6f6f6">
+  Content spans left 6 columns by applying the <code>grid</code> class to the container
+  and the CSS Grid styles <code>grid-column: 1 / span 6</code> to the element.
+  </div>
+  <div class="p-10 mb-20" style="grid-column: 7 / span 6; background-color: #ebeff4">
+  Content spans right 6 columns by applying the <code>grid</code> class to the container
+  and the CSS Grid styles <code>grid-column: 7 / span 6</code> to the element.
+  </div>
+
+  <div class="p-10" style="grid-column: 1 / span 4; background-color: #f6f6f6">
+  Content spans left 3 columns by applying the <code>grid</code> class to the container
+  and the CSS Grid styles <code>grid-column: 1 / span 3</code> to the element.
+  </div>
+  <div class="p-10" style="grid-column: 5 / span 8; background-color: #ebeff4">
+  Content spans right 3 columns by applying the <code>grid</code> class to the container
+  and the CSS Grid styles <code>grid-column: 4 / span 8</code> to the element.
+  </div>
+</div>
+

--- a/stories/global/spacing/Spacing.stories.js
+++ b/stories/global/spacing/Spacing.stories.js
@@ -1,0 +1,3 @@
+import Spacing from './spacing.handlebars'
+
+export const basic = (args) => Spacing(args)

--- a/stories/global/spacing/Spacing.stories.mdx
+++ b/stories/global/spacing/Spacing.stories.mdx
@@ -1,0 +1,56 @@
+import { Meta, Story } from '@storybook/addon-docs/blocks';
+import * as spacingStories from './Spacing.stories.js';
+
+<Meta
+  title="Global/Spacing"
+  args={{
+    class: 'py-20 px-10 mb-10',
+    text: 'Test margin and padding utility classes'
+  }} />
+
+# Spacing
+Sets the margin and padding space between elements on the page.
+
+## Usage
+In local styles, set margin and padding values on elements using
+spacing utility classes.
+
+The classes are named using the format `{property}{sides}-{size}`.
+
+**Property** is one of:
+- `m`: for classes that set margin
+- `p`: for classes that set padding
+
+**Sides** is one of:
+- `t`: for classes that set margin-top or padding-top
+- `b`: for classes that set margin-bottom or padding-bottom
+- `l`:for classes that set margin-left or padding-left
+- `r`: for classes that set margin-right or padding-right
+- `x`: for classes that set both *-left and *-right
+- `y`: for classes that set both *-top and *-bottom
+- blank: for classes that set a margin or padding on all 4 sides of the element
+
+**Size** is a number of pixels from 0 to 60.
+
+### Examples
+- `pt-5` = `padding-top: 5px !important`
+- `pl-10` = `padding-left: 10px !important`
+- `mb-30` = `margin-bottom: 30px !important`
+- `mr-58` = `margin-right: 58px !important`
+- `py-25` = `padding-top: 25px !important; padding-bottom: 25px !important`
+- `mx-14` = `margin-left: 14px !important; margin-right: 14px !important`
+
+## Best practices
+For responsive spacing that changes on different screen sizes, use media queries
+in local stylesheets instead of utility classes to set margin and padding values.
+
+For spacing larger than 60px, set the spacing values in local stylesheets.
+
+## Known issues
+This spacing approach is static and not responsive based on screen size.
+
+## Apply margin and padding classes
+Edit the classes in the Canvas view controls to apply margin and padding spacing 
+changes to the elements.
+
+<Story story={spacingStories.basic} />

--- a/stories/global/spacing/spacing.handlebars
+++ b/stories/global/spacing/spacing.handlebars
@@ -1,0 +1,3 @@
+<div style="background-color: #c5d1dd; border: solid 3px;" class="{{class}}">{{text}}</div>
+<div style="background-color: #c5d1dd; border: solid 3px;" class="{{class}}">{{text}}</div>
+<div style="background-color: #c5d1dd; border: solid 3px;" class="{{class}}">{{text}}</div>

--- a/stories/global/typography/textColor.handlebars
+++ b/stories/global/typography/textColor.handlebars
@@ -1,5 +1,5 @@
 <a href="#" class="text--blue">blue link</a><br/>
-<div style="width: 100%; padding: 10px; background-color: #5c5c5c;">
+<div class="p-10" style="width: 100%; background-color: #5c5c5c;">
   <a class="text--white" href="#">white link</a>
 </div>
 <div style="width: 100%; background-color: #5c5c5c;">

--- a/stylesheets/base/_helpers.scss
+++ b/stylesheets/base/_helpers.scss
@@ -13,33 +13,33 @@
 
 /**
  * Containers and wrapper
- * 1. Use CSS grid to create 12-column grid on container element
- * 2. Use default gutter values for margins
- * 3. Calculate width with gutters
- * 4. Make the container full width without gutters
- * 5. Flexbox wrapper class
+ * 1. Use default gutter values for margins
+ * 2. Calculate width with gutters
+ * 3. Make the container full width without gutters
+ * 4. Flexbox wrapper classes
+ * 5. Use CSS grid to create 12-column grid on container element
  */
 
-.grid {
-  @include twelve-column-grid; /* 1 */
-}
-
 .container {
-  margin: 0 $gutters-default; /* 2 */
-  width: calc(100% - (#{$gutters-default}) * 2); /* 3 */
+  margin: 0 $gutters-default; /* 1 */
+  width: calc(100% - (#{$gutters-default}) * 2); /* 2 */
 }
 
 .container--full-width {
-  width: 100%;
+  width: 100%; /* 3 */
 }
 
-.wrapper { /* 5 */
+.wrapper { /* 4 */
   display: flex;
   justify-content: center;
 }
 
-.flex {
+.flex { /* 4 */
   display: flex;
+}
+
+.grid {
+  @include twelve-column-grid; /* 5 */
 }
 
 /**


### PR DESCRIPTION
Fixes #143 

Adds Storybook docs for layout and spacing, including documenting the layout helper classes and including a story that demonstrates how to use the `grid` helper class to implement a 12-column grid and apply layout styles to the child elements of the grid container.