### PR TITLE
Center header nav correctly

### DIFF
--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -87,7 +87,8 @@
 /**
 * Styles for nav in header.
 * 1. Aligns items to the right on mobile.
-* 2. Aligns items in the center on large screens.
+* 2. Aligns items in the center on large screens, with padding-left set as the width of
+* the social icons.
 **/
 .nav-center {
   display: flex;
@@ -96,6 +97,7 @@
 
   @include lg-up {
     justify-content: center; /* 2 */
+    padding-left: 135px; /* 2 */
   }
 }
 


### PR DESCRIPTION
For the header with dropdown items (like on rockarch.org), the dropdown navigation menus should be centered across the page in the header instead of centered in the space to the left of the social icons. This adds padding to the `.nav-center` class to ensure that the navigation is centered correctly in the header.