### PR TITLE
Eliminate space between footer and bottom of page

### DIFF
--- a/stories/footer/Footer.stories.mdx
+++ b/stories/footer/Footer.stories.mdx
@@ -14,8 +14,12 @@ The footer should be used on all Rockefeller Archive Center web properties.
 
 ## Best practices
 
-Determine if you need to add the secondary footer or not; generally this is only
-relevant if the site uses archival data.
+Determine if you need to add the secondary footer or not; for public-facing sites,
+this is generally only relevant if the site uses archival data. For internal-only RAC
+sites, you may use only the secondary footer.
+
+To ensure that RAC Style Library styles apply to make the footer stay at the bottom of the page
+regardless of page content height, the `<footer>` element myst be a direct child of the `<body>` element.
 
 ## Related components
 

--- a/stories/footer/footer.handlebars
+++ b/stories/footer/footer.handlebars
@@ -1,4 +1,4 @@
-<footer class="footer" role="contentinfo" style="position: relative">
+<footer role="contentinfo">
   <div class="footer-primary">
     <div class="wrapper">
       <div class="grid container">

--- a/stylesheets/base/_base.scss
+++ b/stylesheets/base/_base.scss
@@ -10,6 +10,17 @@ html {
 }
 
 /**
+* Styles applied to the body element ensure that the footer is always on the
+* bottom of the page when combined with the  `margin-top: auto` styles applied
+* to the footer element.
+*/
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/**
  * Make all elements from the DOM inherit from the parent box-sizing
  * Since `*` has a specificity of 0, it does not override the `html` value
  * making all elements inheriting from the root box-sizing value

--- a/stylesheets/layout/_footer.scss
+++ b/stylesheets/layout/_footer.scss
@@ -59,11 +59,13 @@
 
 /**
 * Footer layout styles.
-* Ensures that there is never space between the bottom of the footer and the
-* bottom of the page.
+* Ensures that there is no space between the bottom of the footer and the
+* bottom of the page. This combines with the `flex-direction: column` styles applied
+* to the the <body> element of the page. The footer must be a direct child of the
+* <body> for this to take effect.
 **/
-.footer {
-  position: absolute;
+footer {
+  margin-top: auto;
   width: 100%;
 }
 


### PR DESCRIPTION
- Applies styles to `<body>` and `<footer>` elements to ensure that the footer stays on the bottom of the page regardless of content height. 
- Updates documentation.