### PR TITLE
Add Alert component

### DIFF
--- a/stories/components/alert/Alert.mdx
+++ b/stories/components/alert/Alert.mdx
@@ -38,14 +38,9 @@ they are disruptive and should be used sparingly.
 
 ## Colors
 Alerts come in a number of different colors. Use the following classes:
-- `alert--light-blue`
 - `alert--blue`
 - `alert--navy`
 - `alert--orange`
-- `alert--transparent`
-- `alert--gray`
-- `alert--dark-gray`
-- `alert--black`
 
 <Story of={stories.colors} />
 

--- a/stories/components/alert/Alert.mdx
+++ b/stories/components/alert/Alert.mdx
@@ -1,0 +1,63 @@
+import { Meta, Story } from '@storybook/blocks';
+import * as stories from './Alert.stories.js';
+
+<Meta of={stories} />
+
+# Alerts
+Use a notification banner to tell the user about something they need to know about, 
+but that’s not directly related to the page content.
+
+## When to use
+
+Use alerts to inform users of updates or changes to system status, or to acknowledge or 
+confirm user actions. While alerts are an effective method of communicating with users, 
+they are disruptive and should be used sparingly.
+
+## Best practices
+
+- Use the `role='alert'` attribute to support screen readers.
+- Alerts should not block a user from performing any other task on the screen.
+- Use the base `alert` class along with a color class that sets the background
+  color of the alert.
+- Do not use a notification banner to tell the user about validation errors - 
+  use an error message and error summary instead
+
+## Related components
+
+- Tooltip
+
+## Known issues
+
+`alert--orange` does not meet WCAG requirements for color contrast.
+
+## Basic implementation
+Use javascript to show the alert or hide it when a user clicks on the close button.
+
+<Story of={stories.basic} />
+
+## Colors
+Alerts come in a number of different colors. Use the following classes:
+- `alert--light-blue`
+- `alert--blue`
+- `alert--navy`
+- `alert--orange`
+- `alert--transparent`
+- `alert--gray`
+- `alert--dark-gray`
+- `alert--black`
+
+<Story of={stories.colors} />
+
+## Optional Components
+You can add an title to the alert.
+
+<Story of={stories.title} />
+
+It is also possible to add an icon to the alert.
+
+<Story of={stories.icons} />
+
+## Dismissable Alerts
+If necessary, you can allow users to dismiss alerts by adding a close button. 
+
+<Story of={stories.dismissable} />

--- a/stories/components/alert/Alert.mdx
+++ b/stories/components/alert/Alert.mdx
@@ -17,6 +17,8 @@ they are disruptive and should be used sparingly.
 
 - Use the `role='alert'` attribute to support screen readers.
 - Alerts should not block a user from performing any other task on the screen.
+- Alerts should not disappear automatically. If you want users to be able to remove
+  alerts, use the `alert--dismissable` class.
 - Use the base `alert` class along with a color class that sets the background
   color of the alert.
 - Do not use a notification banner to tell the user about validation errors - 
@@ -31,7 +33,6 @@ they are disruptive and should be used sparingly.
 `alert--orange` does not meet WCAG requirements for color contrast.
 
 ## Basic implementation
-Use javascript to show the alert or hide it when a user clicks on the close button.
 
 <Story of={stories.basic} />
 
@@ -58,6 +59,6 @@ It is also possible to add an icon to the alert.
 <Story of={stories.icons} />
 
 ## Dismissable Alerts
-If necessary, you can allow users to dismiss alerts by adding a close button. 
+If necessary, use JavaScript to allow users to dismiss alerts by clicking a close button. 
 
 <Story of={stories.dismissable} />

--- a/stories/components/alert/Alert.stories.js
+++ b/stories/components/alert/Alert.stories.js
@@ -1,0 +1,35 @@
+import Alert from './alert.handlebars'
+import alertColors from './colors.json'
+
+export default {
+  component: Alert,
+  title: "Components/Alert",
+  args:{
+    dismissable: false,
+    icon: '',
+    title: '',
+    text: 'The Rockefeller Archive Center reading room is now open to researchers.',
+  }
+};
+
+export const basic = (args) => Alert({ ...args, color: 'alert--orange' })
+
+export const colors = (args) => {
+  const alerts = alertColors.map(c => Alert({ ...args, color: c })).join('')
+  return alerts
+}
+
+export const title = (args) => Alert({
+  ...args,
+  color: 'alert--orange', 
+  title: 'Reading Room Update' })
+
+export const icons = (args) => Alert({
+  ...args,
+  color: 'alert--orange',
+  icon: 'error_outline' })
+
+export const dismissable = (args) => Alert({
+  ...args,
+  color: 'alert--orange',
+  dismissable: true })

--- a/stories/components/alert/alert.handlebars
+++ b/stories/components/alert/alert.handlebars
@@ -1,5 +1,9 @@
 <div class="alert {{color}}" role="alert">
-    {{# if dismissable}}<button type="button" class="alert__button" data-dismiss="alert" aria-hidden="true">X</button>{{/if}}
+    {{# if dismissable}}
+        <button class="alert__button" aria-label="Close">
+            <span class="material-icon" aria-hidden="true">close</span>
+        </button>
+    {{/if}}
     {{# if icon}}
     <div class="alert__icon-wrapper">
         <span class="alert__icon" aria-hidden="true">{{icon}}</span>

--- a/stories/components/alert/alert.handlebars
+++ b/stories/components/alert/alert.handlebars
@@ -1,0 +1,12 @@
+<div class="alert {{color}}" role="alert">
+    {{# if dismissable}}<button type="button" class="alert__button" data-dismiss="alert" aria-hidden="true">X</button>{{/if}}
+    {{# if icon}}
+    <div class="alert__icon-wrapper">
+        <span class="alert__icon" aria-hidden="true">{{icon}}</span>
+    </div>
+    {{/if}}
+    <div class="alert__text-wrapper">
+        {{# if title}}<h2 class="alert__header">{{title}}</h2>{{/if}}
+        <p class="alert__text">{{text}}</p>
+    </div>
+</div>

--- a/stories/components/alert/colors.json
+++ b/stories/components/alert/colors.json
@@ -1,11 +1,6 @@
 [
-    "alert--light-blue",
     "alert--blue",
     "alert--navy",
-    "alert--orange",
-    "alert--transparent",
-    "alert--gray",
-    "alert--dark-gray",
-    "alert--black"
+    "alert--orange"
   ]
   

--- a/stories/components/alert/colors.json
+++ b/stories/components/alert/colors.json
@@ -1,0 +1,11 @@
+[
+    "alert--light-blue",
+    "alert--blue",
+    "alert--navy",
+    "alert--orange",
+    "alert--transparent",
+    "alert--gray",
+    "alert--dark-gray",
+    "alert--black"
+  ]
+  

--- a/stories/components/tooltip/Tooltip.mdx
+++ b/stories/components/tooltip/Tooltip.mdx
@@ -24,7 +24,7 @@ the UI.
 
 ## Related components
 
-No related components.
+- Alert
 
 ## Known issues
 

--- a/stylesheets/components/_alert.scss
+++ b/stylesheets/components/_alert.scss
@@ -1,0 +1,109 @@
+// -------------------------------------------
+// This file contains styles related to alerts
+// -------------------------------------------
+
+/**
+* Mixin for alert colors. Accepts arguments for background color, border color and text color.
+**/
+@mixin alert-color($background-color, $border-color, $color) {
+  background-color: $background-color;
+  border-color: $border-color;
+  color: $color;
+}
+
+/**
+* Base alert class.
+**/
+.alert {
+  border: 1px solid;
+  margin: 10px 0;
+  padding: 20px;
+}
+
+/**
+* Wrapper for the alert icon.
+**/
+.alert__icon-wrapper {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+/**
+* Wrapper for text in the alert.
+**/
+.alert__text-wrapper {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+/**
+* Button which closes the alert.
+**/
+.alert__button {
+  appearance: none;
+  background: none;
+  border: 0;
+  color: inherit;
+  float: right;
+  font-family: $sans-serif-stack;
+  margin: -10px;
+}
+
+/**
+* Optional alert header.
+**/
+.alert__header {
+  color: inherit;
+  margin-bottom: 0;
+}
+
+/**
+* Optional alert icon.
+**/
+.alert__icon {
+  @include material-icon(75px, normal);
+
+  padding-right: 10px;
+}
+
+/**
+* Main text of the alert.
+**/
+.alert__text {
+  margin: 0;
+}
+
+/**
+* Styles for alert colors.
+**/
+.alert--light-blue {
+  @include alert-color($solitude-blue, $regal-blue, $regal-blue);
+}
+
+.alert--blue {
+  @include alert-color($yale-blue, $yale-blue, $white);
+}
+
+.alert--navy {
+  @include alert-color($regal-blue, $regal-blue, $white);
+}
+
+.alert--orange {
+  @include alert-color($flame-orange, $flame-orange, $white);
+}
+
+.alert--transparent {
+  @include alert-color(transparent, $dark-grey, $mortar-grey);
+}
+
+.alert--gray {
+  @include alert-color($desert-grey, $dark-grey, $mortar-grey);
+}
+
+.alert--dark-gray {
+  @include alert-color($dark-grey, $dark-grey, $black);
+}
+
+.alert--black {
+  @include alert-color($black, $white, $white);
+}

--- a/stylesheets/components/_alert.scss
+++ b/stylesheets/components/_alert.scss
@@ -76,10 +76,6 @@
 /**
 * Styles for alert colors.
 **/
-.alert--light-blue {
-  @include alert-color($solitude-blue, $regal-blue, $regal-blue);
-}
-
 .alert--blue {
   @include alert-color($yale-blue, $yale-blue, $white);
 }
@@ -90,20 +86,4 @@
 
 .alert--orange {
   @include alert-color($flame-orange, $flame-orange, $white);
-}
-
-.alert--transparent {
-  @include alert-color(transparent, $dark-grey, $mortar-grey);
-}
-
-.alert--gray {
-  @include alert-color($desert-grey, $dark-grey, $mortar-grey);
-}
-
-.alert--dark-gray {
-  @include alert-color($dark-grey, $dark-grey, $black);
-}
-
-.alert--black {
-  @include alert-color($black, $white, $white);
 }

--- a/stylesheets/components/_alert.scss
+++ b/stylesheets/components/_alert.scss
@@ -40,12 +40,10 @@
 * Button which closes the alert.
 **/
 .alert__button {
-  appearance: none;
   background: none;
   border: 0;
   color: inherit;
   float: right;
-  font-family: $sans-serif-stack;
   margin: -10px;
 }
 
@@ -54,7 +52,7 @@
 **/
 .alert__header {
   color: inherit;
-  margin-bottom: 0;
+  margin: 0;
 }
 
 /**

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -23,6 +23,7 @@
 
 // 5. Components
 @import
+  'components/alert',
   'components/badge',
   'components/breadcrumbs',
   'components/button',


### PR DESCRIPTION
Adds an alert component, with options for colors, icons and dismissibility. Fixes #149 

Two questions:
1. I modeled the colors off of the button colors. Is this overboard? Do we need this many colors?
2. I'm getting an accessibility error on the Dismissable Story about focus and elements with `aria-hidden=true` but I'm not sure how to resolve it. Any ideas?