### PR TITLE
Improve implementation of aria-described-by in inputs

### DIFF
--- a/stories/components/textAreaInputs/textareaInputs.handlebars
+++ b/stories/components/textAreaInputs/textareaInputs.handlebars
@@ -1,4 +1,7 @@
 <label for="{{name}}" {{#if hideLabel}}class="visually-hidden"{{/if}}>Message{{#if required}} *{{/if}}</label>
-<textarea name="{{name}}" id="{{name}}" rows="5"{{#if invalid}}class="is-invalid" aria-invalid="true" aria-describedby="{{name}}-error"{{/if}}{{#if required}} required{{/if}}></textarea>
-{{#if helpText}}<p class="input__help-text">255 characters minimum.</p>{{/if}}
+<textarea name="{{name}}" id="{{name}}" rows="5"
+    {{#if invalid}} class="is-invalid" aria-invalid="true" aria-describedby="{{name}}-error"{{/if}}
+    {{#if helpText}} aria-describedby="{{name}}-help"{{/if}}
+    {{#if required}} required{{/if}}></textarea>
+{{#if helpText}}<p id="{{name}}-help" class="input__help-text">250 words maximum.</p>{{/if}}
 {{#if invalid}}<div id="{{name}}-error" class="input__error">This message must be shorter than 255 characters.</div>{{/if}}

--- a/stories/components/textInputs/TextInputs.stories.js
+++ b/stories/components/textInputs/TextInputs.stories.js
@@ -15,4 +15,6 @@ export const required = (args) => TextInput({ ...args, required: true })
 
 export const hideLabel = (args) => TextInput({ ...args, hideLabel: true })
 
+export const helpText = (args) => TextInput({ ...args, helpText: true })
+
 export const withError = (args) => TextInput({ ...args, required: true, invalid: true })

--- a/stories/components/textInputs/textInput.handlebars
+++ b/stories/components/textInputs/textInput.handlebars
@@ -1,5 +1,8 @@
 <label for="{{name}}" {{#if hideLabel}}class="visually-hidden"{{/if}}>{{label}}{{#if required}} *{{/if}}</label>
-<input name="{{name}}"{{#if invalid}} class="is-invalid"{{/if}} type="text" id="{{name}}"{{#if invalid}} aria-invalid="true" aria-describedby="{{name}}-error"{{/if}}{{#if required}} required{{/if}}>
-{{#if helptext}}<div id="{{name}}-error" class="input__error">This field is required.</div>{{/if}}
+<input name="{{name}}" type="text" id="{{name}}" 
+    {{#if invalid}} class="is-invalid" aria-invalid="true" aria-describedby="{{name}}-error"{{/if}}
+    {{#if helpText}} aria-describedby="{{name}}-help"{{/if}}
+    {{#if required}} required{{/if}}>
+{{#if helpText}}<div id="{{name}}-help" class="input__help-text">Please enter your given name.</div>{{/if}}
 {{#if invalid}}<div id="{{name}}-error" class="input__error">This field is required.</div>{{/if}}
 


### PR DESCRIPTION
Update Handlebars templates for `textAreaInput` and `textInput` so that `aria-describedby` attribute is used correctly to point to help text.

Fixes #170