### PR TITLE
Document Helper Classes

### DIFF
--- a/stories/global/colors/Colors.mdx
+++ b/stories/global/colors/Colors.mdx
@@ -13,7 +13,7 @@ the orange of the Rockefeller Archive Center logo.
   <ColorItem title="Primary color palette" colors={[colors.flameOrange, colors.regalBlue]} />
 </ColorPalette>
 
-## Usage
+## Best practices
 For accessibility, do not use color alone to communicate information. To meet
 WCAG 2.x Level AA, text must have a contrast ratio of at least 4.5:1, or 3:1 for
 large text (defined as 14pt bold or 18pt).

--- a/stories/global/helpers/Helpers.mdx
+++ b/stories/global/helpers/Helpers.mdx
@@ -1,0 +1,42 @@
+import { Meta, Story } from '@storybook/blocks';
+import * as stories from './ListUnstyled.stories.js';
+
+<Meta of={stories} />
+
+# Helper Classes
+The RAC Style Library includes CSS classes that are available to style elements and
+components as needed to allow for flexibility.
+
+## When to use
+- `list--unstyled`: Use to remove the default bullets and left indent from an
+unordered list.
+- `visually--hidden`: Hide an element visually while still being available for screen
+readers.
+- `show-on-focus`: When an element receives focus, it will appear visually. This can be
+combined with the `visually-hidden` class.
+- `hide-on-lg-up`, `show-on-lg-up` `hide-on-md-up`, `show-on-md-up`: Hide or show
+elements only when the screen display size is large or medium. When items are hidden,
+they will have `display:none;` applied, which hides them both visually and from
+screen readers.
+
+## Best practices
+Use `visually--hidden` in targeted circumstances to improve accessibility,
+but note that it is almost always better not to hide content from some users and make
+it available to other users, so consider design approaches that don't require this.
+
+Use `show-on-focus` sparingly. It is usually best for usability and accessibility not
+to hide elements and surprise users with new content only when an element receives focus.
+
+## Related components
+- Card: `list--unstyled`.
+- Header: `list--unstyled`, `hide-on-lg-up`, `show-on-lg-up`.
+- Skip Link: `visually-hidden` and `show-on-focus`.
+
+## Known issues
+There are no known issues.
+
+## Unstyled List
+Applying `list--unstyled` removes the default bullets and left margin from unordered lists.
+
+<Story of={stories.listUnstyled} />
+

--- a/stories/global/helpers/ListUnstyled.stories.js
+++ b/stories/global/helpers/ListUnstyled.stories.js
@@ -1,0 +1,11 @@
+import ListUnstyled from './listUnstyled.handlebars'
+
+export default {
+  component: ListUnstyled,
+  title: "Global/Helpers",
+  args: {
+    listUnstyled: true
+  }
+};
+
+export const listUnstyled = (args) => ListUnstyled(args)

--- a/stories/global/helpers/listUnstyled.handlebars
+++ b/stories/global/helpers/listUnstyled.handlebars
@@ -1,0 +1,12 @@
+<p>This is an unordered list:</p>
+<ul
+      {{#if listUnstyled}}
+        class="list--unstyled"
+      {{/if}}>
+    <li>Asia Society</li>
+    <li>Asian Cultural Council</li>
+    <li>China Medical Board, Inc.</li>
+    <li>Commonwealth Fund</li>
+    <li>Downtown-Lower Manhattan Association, Inc.</li>
+    <li>Ford Foundation</li>
+  </ul>

--- a/stories/global/typography/Typography.mdx
+++ b/stories/global/typography/Typography.mdx
@@ -52,7 +52,7 @@ There are currently only partially defined styles for `h5` and `h6`.
 
 ### Implementation
 
-A bottom border can be added by applying the `heading--bottom-border` class to the heading element.
+A bottom border can be added by applying the `heading--dotted-border` class to the heading element.
 
 <Story of={headingsStories.headings} />
 

--- a/stylesheets/base/_helpers.scss
+++ b/stylesheets/base/_helpers.scss
@@ -56,6 +56,14 @@
   @include show-on-lg-up;
 }
 
+.hide-on-md-up {
+  @include hide-on-md-up;
+}
+
+.show-on-md-up {
+  @include show-on-md-up;
+}
+
 .show-on-focus {
   @include show-on-focus;
 }

--- a/stylesheets/base/_helpers.scss
+++ b/stylesheets/base/_helpers.scss
@@ -3,12 +3,11 @@
 // -----------------------------------------------------------------------------
 
 /**
- * Clear inner floats
+ * Remove the default bullet and left indent from an unordered list
  */
-.clearfix::after {
-  clear: both;
-  content: '';
-  display: table;
+.list--unstyled {
+  list-style: none;
+  padding-left: 0;
 }
 
 /**
@@ -40,18 +39,6 @@
 
 .grid {
   @include twelve-column-grid; /* 5 */
-}
-
-/**
- * Hide text while making it readable for screen readers
- * 1. Needed in WebKit-based browsers because of an implementation bug;
- *    See: https://code.google.com/p/chromium/issues/detail?id=457146
- */
-.hide-text {
-  overflow: hidden;
-  padding: 0; /* 1 */
-  text-indent: 101%;
-  white-space: nowrap;
 }
 
 .visually-hidden {

--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -107,14 +107,6 @@ ul {
 }
 
 /**
- * Remove the default bullet and left indent from an unordered list
- */
-.list--unstyled {
-  list-style: none;
-  padding-left: 0;
-}
-
-/**
  * Headings
  */
 


### PR DESCRIPTION
Fixes #193 

Cleans up unused classes and documents helper classes in Storybook including:
- `list--unstyled`
- `visually--hidden`
- `show-on-focus`
- `hide-on-lg-up`, `show-on-lg-up` `hide-on-md-up`, and `show-on-md-up`