### PR TITLE
Fix header layout and add Storybook intro page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # RAC Style Library and Guide
 Style library and guide for Rockefeller Archive Center websites.
 
-[![Build Status](https://travis-ci.com/RockefellerArchiveCenter/styles.svg?branch=base)](https://travis-ci.com/RockefellerArchiveCenter/styles)
-
 ## Getting started
 Install dependencies using `yarn install`.
 

--- a/stories/Introduction.mdx
+++ b/stories/Introduction.mdx
@@ -1,4 +1,4 @@
-# [Rockefeller Archive Center](https://roockarch.org) Style Guide
+# [Rockefeller Archive Center](https://rockarch.org) Style Guide
 Welcome to our Style Guide, an open source [Storybook](https://storybook.js.org/) component-based library to enable 
 the quick development of high-quality, accessible, and maintainable user interfaces.
 

--- a/stories/Introduction.mdx
+++ b/stories/Introduction.mdx
@@ -1,4 +1,4 @@
-# Rockefeller Archive Center Style Guide
+# [Rockefeller Archive Center](https://roockarch.org) Style Guide
 Welcome to our Style Guide, an open source [Storybook](https://storybook.js.org/) component-based library to enable 
 the quick development of high-quality, accessible, and maintainable user interfaces.
 
@@ -8,7 +8,7 @@ file into your project, replacing v.x.x.x with the current version of the librar
 `<link rel="stylesheet" href="https://assets.rockarch.org/vx.x.x/main.min.css">`
 
 2. Import specific [image asset files](https://github.com/RockefellerArchiveCenter/styles/tree/base/stylesheets/assets/img), 
-like favicons or logos, from `https://assets.rockarch.org/img/`.
+like a favicon or logo, from `https://assets.rockarch.org/img/`.
 
 3. Create UIs using the HTML structure and CSS classes defined for individual components in this guide,
 noting the best practices and implementation suggestions in the component documentation.

--- a/stories/Introduction.mdx
+++ b/stories/Introduction.mdx
@@ -1,0 +1,22 @@
+# Rockefeller Archive Center Style Guide
+Welcome to our Style Guide, an open source [Storybook](https://storybook.js.org/) component-based library to enable 
+the quick development of high-quality, accessible, and maintainable user interfaces.
+
+## How to use the library and guide
+1. Import the [RAC Style Library](https://github.com/RockefellerArchiveCenter/styles) CSS
+file into your project, replacing v.x.x.x with the current version of the library:  
+`<link rel="stylesheet" href="https://assets.rockarch.org/vx.x.x/main.min.css">`
+
+2. Import specific [image asset files](https://github.com/RockefellerArchiveCenter/styles/tree/base/stylesheets/assets/img), 
+like favicons or logos, from `https://assets.rockarch.org/img/`.
+
+3. Create UIs using the HTML structure and CSS classes defined for individual components in this guide,
+noting the best practices and implementation suggestions in the component documentation.
+
+4. Reference "global" stories and documentation in this guide for available colors, typography,
+and helper classes for UI layout, spacing, and other basic styling utility.
+
+## Suggest an improvement
+If there is a component we need, a bug or inconsistency, an opportunity to improvement
+accessibility, or other idea to make this resource more useful, let us know! File an issue
+in our [RAC Style Library](https://github.com/RockefellerArchiveCenter/styles) GitHub repository.

--- a/stories/components/header/Header.stories.js
+++ b/stories/components/header/Header.stories.js
@@ -15,8 +15,8 @@ export const withTextBrand = () => {
   const headers = headerColors.map(c => Header({
     class: c,
     withTextBrand: true,
-    brandTitle: 'library.rockarch.org',
-    brandSubtitle: 'The Online Bibliographic Catalog of Rockefeller Archive Center'
+    brandTitle: 'blog.rockarch.org',
+    brandSubtitle: 'Rockefeller Archive Center Blog'
   })).join('')
   return headers
 }

--- a/stories/components/header/header.handlebars
+++ b/stories/components/header/header.handlebars
@@ -5,7 +5,7 @@
       {{#if withTextBrand}}
         <div class="header__brand header__brand--text">
           <a href="/" class="header__brand-title">{{brandTitle}}</a>
-          <p class="header__brand-subtitle">{{brandSubtitle}}</p>
+          <div class="header__brand-subtitle">{{brandSubtitle}}</div>
         </div>
       {{/if}}
 

--- a/stylesheets/layout/_header.scss
+++ b/stylesheets/layout/_header.scss
@@ -27,7 +27,6 @@
 
   @include md-up {
     font-size: 15px;
-    line-height: 18px;
   }
 
   &:hover,
@@ -82,17 +81,20 @@
 }
 
 /**
-* Styles for header branding section that includes title, subtitle, and/or image.
+* Styles for header branding section that includes title and subtitle.
 **/
 .header__brand {
   align-content: center;
   display: flex;
-  flex-wrap: wrap;
+  flex-flow: column wrap;
+  justify-content: center;
   margin-right: auto;
   padding-left: 15px;
   z-index: 3;
 
   @include lg-up {
+    flex-direction: row;
+    justify-content: flex-start;
     padding-left: 65px;
   }
 }
@@ -100,26 +102,15 @@
 .header__brand-title {
   @include header-title;
 
-  margin: 0 10px 0 0;
+  margin: 0 10px 5px 0;
+
+  @include lg-up {
+    margin: 0 10px 0 0;
+  }
 }
 
 .header__brand-subtitle {
   @include header-subtitle;
-
-  margin: 4px 0 0;
-}
-
-/**
-* Styles for header brand image.
-* 1. Specifies height to fit inside the header
-**/
-.header__brand-image {
-  line-height: 0;
-  margin: 0;
-
-  img {
-    height: 56px; /* 1 */
-  }
 }
 
 /**


### PR DESCRIPTION
Fix #220 and #219 
For review: How's the intro page look? Is it missing any important information?

Note: header changes include the HTML change to use a `<div>` instead of `<p>` for the subtitle.