### PR TITLE
Remove twitter + flickr, add linkedin to social icons

### DIFF
--- a/stories/components/socialIcons/socialIcons.handlebars
+++ b/stories/components/socialIcons/socialIcons.handlebars
@@ -1,14 +1,4 @@
 <div class="social-icons">
-  <a href="https://twitter.com/rockarch_org" aria-label="Twitter">
-    <span class="social-icons__icon">
-      <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-        <title>Twitter Logo</title>
-        <path fill="#192E49"
-          d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z">
-        </path>
-      </svg>
-    </span>
-  </a>
   <a href="https://www.facebook.com/RockefellerArchiveCenter" aria-label="Facebook">
     <span class="social-icons__icon">
       <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
@@ -27,6 +17,16 @@
       </svg>
     </span>
   </a>
+  <a href="https://www.linkedin.com/company/rockefeller-archive-center" aria-label="LinkedIn">
+    <span class="social-icons__icon">
+      <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <title>LinkedIn Logo</title>
+        <path transform="scale(1.5)" fill="#192E49"
+          d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854zm4.943 12.248V6.169H2.542v7.225zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248S2.4 3.226 2.4 3.934c0 .694.521 1.248 1.327 1.248zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016l.016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225z"/>
+        </path>
+      </svg>
+    </span>
+  </a>
   <a href="https://www.youtube.com/channel/UCks9ctz4OF9tMNOTrRkWIZg" aria-label="YouTube">
     <span class="social-icons__icon">
       <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
@@ -34,20 +34,6 @@
         <path fill="#192E49"
           d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z">
         </path>
-      </svg>
-    </span>
-  </a>
-  <a href="https://www.flickr.com/photos/147074352@N05/" aria-label="Flickr">
-    <span class="social-icons__icon"><svg aria-hidden="true" focusable="false" width="18px" height="24px" viewBox="0 0 18 8" version="1.1" xmlns="http://www.w3.org/2000/svg">
-        <title>Flickr Logo</title>
-        <g id="Style-Guide" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-          <g id="Style-Guide-/-Navigation" transform="translate(-1553.000000, -319.000000)" fill="#192E49">
-            <g id="Group-2" transform="translate(1552.999996, 318.500000)">
-              <circle id="Oval" cx="3.9374999" cy="4.41964274" r="3.9374999"></circle>
-              <circle id="Oval-Copy-5" cx="14.0624996" cy="4.41964274" r="3.9374999"></circle>
-            </g>
-          </g>
-        </g>
       </svg>
     </span>
   </a>

--- a/stylesheets/components/_social-icons.scss
+++ b/stylesheets/components/_social-icons.scss
@@ -9,10 +9,10 @@
 .social-icons {
   display: flex;
   justify-content: space-between;
-  max-width: 250px;
+  max-width: 200px;
 
   a {
-    line-height: inherit; /* 1 */
+    line-height: 0; /* 1 */
     margin: 0;
     text-decoration: none;
   }


### PR DESCRIPTION
Fix #178 
In consultation with social media team and org leadership, determined that the social media icons/links should be: Facebook, Instagram, LinkedIn, and YouTube.