### PR TITLE
Revert button line-height changes

### DIFF
--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -72,7 +72,7 @@
   font-weight: abs.$font-weight-bold;
 
   .material-icon {
-    @include abs.material-icon(18px);
+    @include abs.material-icon(18px, 18px);
   }
 }
 
@@ -82,7 +82,7 @@
   font-weight: abs.$font-weight-bold;
 
   .material-icon {
-    @include abs.material-icon(16px);
+    @include abs.material-icon(16px, 16px);
   }
 }
 
@@ -90,7 +90,7 @@
   @include button-size(12px, 15px, 13px 14px);
 
   .material-icon {
-    @include abs.material-icon(20px);
+    @include abs.material-icon(20px, 15px);
   }
 }
 
@@ -98,7 +98,7 @@
   @include button-size(14px, 18px, 18px);
 
   .material-icon {
-    @include abs.material-icon(20px);
+    @include abs.material-icon(20px, 17px);
   }
 }
 


### PR DESCRIPTION
Revert erroneous changes made in PR #235 to button material icon line height at various button sizes.