### PR TITLE
Allow dropdown item text to wrap

### DIFF
--- a/stories/components/dropdown/dropdown.handlebars
+++ b/stories/components/dropdown/dropdown.handlebars
@@ -15,7 +15,7 @@
     <a id="menu-item-1" class="btn btn--orange dropdown__btn dropdown__item--orange" 
       tabindex="-1" role="menuitem">
       <span class="material-icon" aria-hidden="true">local_library</span>
-      Request in Reading Room
+      Request Items in Reading Room
     </a>
     <a id="menu-item-2" class="btn btn--orange dropdown__btn dropdown__item--orange" 
       tabindex="-1" role="menuitem">

--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -39,6 +39,13 @@
 }
 
 /**
+* Allow text to wrap in dropdown list items.
+**/
+.dropdown__list .btn {
+  white-space: wrap;
+}
+
+/**
 * Styles for a dropdown list of items used on small screens
 * like the dropdown opened by the navigation menu button.
 * 1. Keeps other page content from covering the dropdown


### PR DESCRIPTION
Fix #247

Lengthens text in dropdown component story to show wrapping, and adjusts dropdown styles to allow items with `btn` class to wrap.

<img width="286" alt="image" src="https://github.com/user-attachments/assets/7d4aaa96-dd01-4ce3-85e2-53ef773d9c77" />
