### PR TITLE
Fix wrapping for long words/urls in alert component

### DIFF
--- a/stylesheets/components/_alert.scss
+++ b/stylesheets/components/_alert.scss
@@ -15,6 +15,7 @@
 
 /**
 * Base alert class.
+* 1. Ensure all text wraps in the alert without overflow.
 **/
 .alert {
   align-items: center;
@@ -22,6 +23,7 @@
   display: flex;
   margin: 10px 0;
   padding: 20px;
+  overflow-wrap: anywhere; /* 1 */
 }
 
 /**


### PR DESCRIPTION
Bug fix. Ensures that strings with no spaces don't continue outside the alert container. 