### PR TITLE
Fix known color contrast issues

### DIFF
--- a/stories/components/alert/Alert.mdx
+++ b/stories/components/alert/Alert.mdx
@@ -35,7 +35,7 @@ to the content in this region.
 
 ## Known issues
 
-`alert--orange` does not meet WCAG requirements for color contrast.
+No known issues.
 
 ## Basic implementation
 

--- a/stories/components/breadcrumbs/Breadcrumbs.mdx
+++ b/stories/components/breadcrumbs/Breadcrumbs.mdx
@@ -29,7 +29,6 @@ The last item in a breadcrumb trail should indicate the current page using
 
 ## Known issues
 
-Color `$crusta-orange (#f16741)` on link hover/focus does not meet WCAG requirements for color 
-contrast against most background colors.
+No known issues.
 
 <Story of={stories.basic} />

--- a/stories/components/button/Button.mdx
+++ b/stories/components/button/Button.mdx
@@ -33,7 +33,7 @@ saving their information.
 
 ## Known issues
 
-`btn--orange` does not meet WCAG requirements for color contrast.
+No known issues.
 
 ## Colors
 Buttons come in a variety of colors:

--- a/stories/components/dropdown/Dropdown.mdx
+++ b/stories/components/dropdown/Dropdown.mdx
@@ -29,7 +29,7 @@ use the `menu` or `menuitem` aria roles . Refer to the header styles for more de
 
 ## Known issues
 
-The orange background with white text does not meet WCAG requirements for color contrast.
+No known issues.
 
 ## Basic implementation
 Use javascript to enable the button to open and close the dropdown menu. To see what this looks

--- a/stories/components/pagination/Pagination.mdx
+++ b/stories/components/pagination/Pagination.mdx
@@ -37,6 +37,6 @@ No related components.
 
 ## Known issues
 
-Color `flame-orange (#d7521d)` does not meet WCAG requirements for color contrast.
+No known issues.
 
 <Story of={stories.basic} />

--- a/stories/components/skipLink/SkipLink.mdx
+++ b/stories/components/skipLink/SkipLink.mdx
@@ -31,7 +31,7 @@ Table of contents (includes a skip link example)
 
 ## Known issues
 
-Does not meet WCAG requirements for color contrast.
+No known issues.
 
 ## Default implementation
 

--- a/stories/components/tableOfContents/TableOfContents.mdx
+++ b/stories/components/tableOfContents/TableOfContents.mdx
@@ -30,7 +30,7 @@ No related components.
 
 ## Known issues
 
-`toc--orange` does not meet WCAG requirements for color contrast.
+No known issues.
 
 ## Colors
 The table of contents comes in a variety of colors. Use the `toc--neutral`,

--- a/stories/global/colors/Colors.mdx
+++ b/stories/global/colors/Colors.mdx
@@ -6,11 +6,12 @@ import {colors} from './Colors'
 
 # Colors
 
-The two primary colors are flame-orange and the complimentary regal-blue. The orange matches
-the orange of the Rockefeller Archive Center logo.
+The two primary colors are umber-brown and the complimentary regal-blue. Flame-orange is the color
+of the Rockefeller Archive Center logo, but that color is not widely used in components to support
+sufficient color contrast ratios for accessibility.
 
 <ColorPalette>
-  <ColorItem title="Primary color palette" colors={[colors.flameOrange, colors.regalBlue]} />
+  <ColorItem title="Primary color palette" colors={[colors.umberBrown, colors.regalBlue]} />
 </ColorPalette>
 
 ## Best practices

--- a/stories/global/typography/Typography.mdx
+++ b/stories/global/typography/Typography.mdx
@@ -88,8 +88,7 @@ with different text colors, so use the specific component color classes when app
 
 ### Known issues
 
-Color `$flame-orange (#d7521d)` does not meet WCAG requirements for color
-contrast against most background colors.
+No known issues.
 
 ### Implementation
 

--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -1,4 +1,5 @@
 @use '../abstracts' as abs;
+@use 'sass:color';
 
 // -----------------------------------------------------------------------------
 // This file contains basic typography styles for copy text
@@ -81,7 +82,7 @@ a {
   @include abs.on-event {
     @include abs.transition-default;
 
-    color: abs.$rust-red; /* 1 */
+    color: color.adjust(abs.$umber-brown, $lightness: -10%); /* 1 */
     cursor: pointer; /* 2 */
     text-decoration: none; /* 3 */
   }

--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -75,13 +75,13 @@ i {
  * 3. Remove link underline
  */
 a {
-  color: abs.$flame-orange;
+  color: abs.$umber-brown;
   text-decoration: underline;
 
   @include abs.on-event {
     @include abs.transition-default;
 
-    color: abs.$crusta-orange; /* 1 */
+    color: abs.$rust-red; /* 1 */
     cursor: pointer; /* 2 */
     text-decoration: none; /* 3 */
   }
@@ -222,7 +222,7 @@ h6 a {
 }
 
 .text--orange {
-  color: abs.$flame-orange;
+  color: abs.$umber-brown;
 }
 
 .text--white {

--- a/stylesheets/components/_alert.scss
+++ b/stylesheets/components/_alert.scss
@@ -81,5 +81,5 @@
 }
 
 .alert--orange {
-  @include alert-color(abs.$flame-orange, abs.$flame-orange, abs.$white);
+  @include alert-color(abs.$umber-brown, abs.$umber-brown, abs.$white);
 }

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -139,12 +139,12 @@
 }
 
 .btn--orange {
-  @include button-color(abs.$flame-orange, abs.$flame-orange, abs.$white);
+  @include button-color(abs.$umber-brown, abs.$umber-brown, abs.$white);
 
   &:hover,
   &:focus {
-    background-color: color.adjust(abs.$flame-orange, $lightness: -10%);
-    border-color: color.adjust(abs.$flame-orange, $lightness: -10%);
+    background-color: color.adjust(abs.$umber-brown, $lightness: -10%);
+    border-color: color.adjust(abs.$umber-brown, $lightness: -10%);
     color: abs.$desert-grey;
   }
 }

--- a/stylesheets/components/_card.scss
+++ b/stylesheets/components/_card.scss
@@ -101,7 +101,7 @@
   &:focus {
     @include abs.transition-default;
 
-    box-shadow: 0 0 0 2px abs.$crusta-orange, 0 0 8px 2px color.adjust(abs.$silver-grey, $lightness: 10%);
+    box-shadow: 0 0 0 2px abs.$umber-brown, 0 0 8px 2px color.adjust(abs.$silver-grey, $lightness: 10%);
   }
 }
 

--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -71,7 +71,7 @@
 }
 
 .dropdown__list--orange {
-  background-color: abs.$flame-orange;
+  background-color: abs.$umber-brown;
 }
 
 /**

--- a/stylesheets/components/_inputs.scss
+++ b/stylesheets/components/_inputs.scss
@@ -173,8 +173,8 @@ fieldset {
 
 .checkbox--orange:not(:checked) + label::after,
 .checkbox--orange:checked + label::after {
-  background-color: abs.$flame-orange;
-  border: 1px solid abs.$flame-orange;
+  background-color: abs.$umber-brown;
+  border: 1px solid abs.$umber-brown;
   color: abs.$white;
 }
 
@@ -231,7 +231,7 @@ fieldset .input-group {
 }
 
 .radiobutton--orange {
-  accent-color: abs.$flame-orange;
+  accent-color: abs.$umber-brown;
 }
 
 .radiobutton--grey {

--- a/stylesheets/components/_minimap.scss
+++ b/stylesheets/components/_minimap.scss
@@ -117,7 +117,7 @@ $grid-col-count: 20;
 }
 
 .minimap__record-hit {
-  @include minimap-hit(abs.$flame-orange);
+  @include minimap-hit(abs.$umber-brown);
 }
 
 /**
@@ -128,5 +128,5 @@ $grid-col-count: 20;
 }
 
 .minimap__record-hit--active {
-  @include minimap-hit-active (abs.$flame-orange);
+  @include minimap-hit-active (abs.$umber-brown);
 }

--- a/stylesheets/components/_skip-link.scss
+++ b/stylesheets/components/_skip-link.scss
@@ -39,7 +39,7 @@
  * Skip link mixin for colors. Allows users to set background and color of skip link
  * with $background and $color variables. $background and $color are set to work with RAC header.
 **/
-@mixin skip-link-color($background: abs.$flame-orange, $color: abs.$desert-grey) {
+@mixin skip-link-color($background: abs.$umber-brown, $color: abs.$desert-grey) {
   background: $background;
   color: $color;
 

--- a/stylesheets/components/_social-icons.scss
+++ b/stylesheets/components/_social-icons.scss
@@ -36,7 +36,7 @@
     @media (prefers-reduced-motion: no-preference) {
       svg g,
       svg path {
-        fill: abs.$flame-orange;
+        fill: abs.$umber-brown;
         transition: abs.$transition-default;
       }
     }

--- a/stylesheets/components/_table-of-contents.scss
+++ b/stylesheets/components/_table-of-contents.scss
@@ -108,7 +108,7 @@
 }
 
 .toc--orange {
-  background-color: abs.$flame-orange;
+  background-color: abs.$umber-brown;
 }
 
 .toc--orange .toc__link-item,

--- a/stylesheets/layout/_footer.scss
+++ b/stylesheets/layout/_footer.scss
@@ -34,7 +34,7 @@
 
   &:hover,
   &:focus {
-    color: abs.$flame-orange;
+    color: abs.$rust-red;
   }
 }
 

--- a/stylesheets/layout/_header.scss
+++ b/stylesheets/layout/_header.scss
@@ -74,7 +74,7 @@
 }
 
 .header--white .nav__btn--dropdown[aria-expanded='true'] {
-  color: abs.$flame-orange;
+  color: abs.$umber-brown;
 }
 
 .header--blue {


### PR DESCRIPTION
Improve known accessibility issues for color contrast. Fix #263 

Replace $flame-orange with $umber-brown as primary color. This change impacts:

- Alert
- Button
- Card box shadow
- Dropdown
- Header with dropdown items
- Minimap
- Radiobutton
- Skip link
- Table of contents
- Standard typography links (links in footer were changed to $rust-red to work with darker background)

