### PR TITLE
Improve table and card color contrast

### DIFF
--- a/stories/components/card/Card.mdx
+++ b/stories/components/card/Card.mdx
@@ -31,11 +31,11 @@ with the base styles providing one column that takes up the full width of its co
 For example, for 4 card columns on large screens and 3 columns on medium screens, use:
 ```
 .card-list {
-  @include md-up {
+  @media screen and (min-width: 580px) {
     grid-template-columns: repeat(3, 1fr);
   }
 
-  @include lg-up {
+  @media screen and (min-width: 1024px) {
     grid-template-columns: repeat(4, 1fr);
   }
 }
@@ -53,7 +53,8 @@ However, the card footer is optional.
 A card can be used flexibly as a content container that is not
 part of a list or a link by adding the `card--container` class and adjusting
 the HTML structure for the desired content. Optionally, `card--blue` is available
-to adjust the background color. This example includes an `h2` as the card title:
+to adjust the background color. This example includes an `h2`, paragraph, and link text
+without the card body, title, or text classes:
 
 <Story of={stories.container} />
 

--- a/stories/components/card/card.handlebars
+++ b/stories/components/card/card.handlebars
@@ -14,17 +14,13 @@
   </ul>
 {{else}}
 
-  <div class="card card--container">
-    <div class="card__body">
-      <h2 class="card__title">{{titleText}}</h2>
-      <p class="card__body-text">{{bodyText}}</p>
-    </div>
+  <div class="card card--container flex--column">
+    <h2>{{titleText}}</h2>
+    <p><a href="no-target">{{bodyText}}</a></p>
   </div>
-  <div class="card card--container card--blue">
-    <div class="card__body">
-      <h2 class="card__title">{{titleText}}</h2>
-      <p class="card__body-text">{{bodyText}}</p>
-    </div>
+  <div class="card card--container card--blue flex--column">
+    <h2>{{titleText}}</h2>
+    <p><a href="no-target">{{bodyText}}</a></p>
   </div>
 
 {{/if}}

--- a/stories/components/table/table.handlebars
+++ b/stories/components/table/table.handlebars
@@ -19,7 +19,7 @@
         </tr>
         <tr>
             {{#if inputs}}<td><input type="checkbox" id="3" aria-labelledby="select row03"></td>{{/if}}
-            <th scope="row"{{#if inputs}} id="row03"{{/if}}>Brownie Purveyors Society</th>
+            <th scope="row"{{#if inputs}} id="row03"{{/if}}><a href="" target="_blank">Brownie Purveyors Society</a></th>
             <td>2024</td>
         </tr>
         <tr>

--- a/stylesheets/components/_card.scss
+++ b/stylesheets/components/_card.scss
@@ -165,6 +165,11 @@
   }
 }
 
+/* Ensure sufficient color contrast for links in container cards */
+.card--container a {
+  color: abs.$rust-red;
+}
+
 .card--container .card__title {
   &::after {
     position: relative; /* 2 */

--- a/stylesheets/components/_table.scss
+++ b/stylesheets/components/_table.scss
@@ -67,6 +67,13 @@
 }
 
 /**
+* Use darker link color for links in striped table to ensure sufficient color contrast
+**/
+.table.table-striped a {
+  color: abs.$rust-red;
+}
+
+/**
 * Make a table scroll horizontally when it's too wide for the screen
 **/
 .table-responsive {


### PR DESCRIPTION
Address #263 
For the striped table and card background colors, makes the link color should be darker to achieve sufficient contrast.

Also updates stories to include link examples in table and card stories.