### PR TITLE
Exclude link styled us btn from color adjustment in cards and tables

### DIFF
--- a/stylesheets/components/_card.scss
+++ b/stylesheets/components/_card.scss
@@ -165,8 +165,10 @@
   }
 }
 
-/* Ensure sufficient color contrast for links in container cards */
-.card--container a {
+/** Ensure sufficient color contrast for links in container cards
+* excluding links styled as buttons
+**/
+.card--container a:not(.btn) {
   color: abs.$rust-red;
 }
 

--- a/stylesheets/components/_table.scss
+++ b/stylesheets/components/_table.scss
@@ -68,8 +68,9 @@
 
 /**
 * Use darker link color for links in striped table to ensure sufficient color contrast
+* excluding links styled as buttons
 **/
-.table.table-striped a {
+.table.table-striped a:not(.btn) {
   color: abs.$rust-red;
 }
 


### PR DESCRIPTION
Fix bug introduced in PR #268 so that links styled as buttons maintain the correct colors inside card--container and table-striped elements.