### PR TITLE
Addresses issues from RAC accessibility audit

### DIFF
--- a/stories/components/card/Card.mdx
+++ b/stories/components/card/Card.mdx
@@ -42,6 +42,9 @@ For example, for 4 card columns on large screens and 3 columns on medium screens
 ```
 
 By default, cards are designed to be a list of links with a body and a footer.
+In a list, the links should be marked up as headings with the class `card__title`
+applied. In this example, they are designated as an `<h2>` element, but the
+level should be adjusted based on page structure.
 
 <Story of={stories.basic} />
 

--- a/stories/components/card/Card.mdx
+++ b/stories/components/card/Card.mdx
@@ -31,11 +31,11 @@ with the base styles providing one column that takes up the full width of its co
 For example, for 4 card columns on large screens and 3 columns on medium screens, use:
 ```
 .card-list {
-  @media screen and (min-width: 580px) {
+  @media screen and (min-width: 36.25em) {
     grid-template-columns: repeat(3, 1fr);
   }
 
-  @media screen and (min-width: 1024px) {
+  @media screen and (min-width: 64em) {
     grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/stories/components/card/card.handlebars
+++ b/stories/components/card/card.handlebars
@@ -2,7 +2,7 @@
   <ul class="card-list">
     <li class="card">
       <div class="card__body">
-        <a class="card__title" href="{{linkTarget}}">{{titleText}}</a>
+        <h2 class="card__title"><a class="card__title" href="{{linkTarget}}">{{titleText}}</a></h2>
         <p class="card__body-text">{{bodyText}}</p>
       </div>
       {{#if footerText}}

--- a/stories/components/dropdown/dropdown.handlebars
+++ b/stories/components/dropdown/dropdown.handlebars
@@ -32,11 +32,11 @@
       <span class="material-icon" aria-hidden="true">get_app</span>
       Download as .csv
     </a>
-    <a id="menu-item-5" class="btn btn--orange dropdown__btn dropdown__item--orange" 
+    <button id="menu-item-5" class="btn btn--orange dropdown__btn dropdown__item--orange" 
       tabindex="0" role="menuitem">
       <span class="material-icon" aria-hidden="true">delete</span>
       Remove All Items
-    </a>
+    </button>
   </div>
   {{/if}}
 </div>

--- a/stories/components/dropdown/dropdown.handlebars
+++ b/stories/components/dropdown/dropdown.handlebars
@@ -8,32 +8,32 @@
   <div class="dropdown__list dropdown__list--orange dropdown__list--slide-down open" role="menu">
     <a id="menu-item-0" class="btn btn--orange dropdown__btn dropdown__item--orange"
       href={{linkTarget}}
-      tabindex="-1" role="menuitem">
+      tabindex="0" role="menuitem">
       <span class="material-icon" aria-hidden="true">account_balance</span>
       Schedule a Visit
     </a>
     <a id="menu-item-1" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="-1" role="menuitem">
+      tabindex="0" role="menuitem">
       <span class="material-icon" aria-hidden="true">local_library</span>
       Request Items in Reading Room
     </a>
     <a id="menu-item-2" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="-1" role="menuitem">
+      tabindex="0" role="menuitem">
       <span class="material-icon" aria-hidden="true">content_copy</span>
       Request Copies
       </a>
     <a id="menu-item-3" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="-1" role="menuitem">
+      tabindex="0" role="menuitem">
       <span class="material-icon" aria-hidden="true">email</span>
       Email List
     </a>
     <a id="menu-item-4" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="-1" role="menuitem">
+      tabindex="0" role="menuitem">
       <span class="material-icon" aria-hidden="true">get_app</span>
       Download as .csv
     </a>
     <a id="menu-item-5" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="-1" role="menuitem">
+      tabindex="0" role="menuitem">
       <span class="material-icon" aria-hidden="true">delete</span>
       Remove All Items
     </a>

--- a/stories/components/form/allForms.mdx
+++ b/stories/components/form/allForms.mdx
@@ -1,0 +1,34 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Components/Form/All Form Components" />
+
+# All Form Components
+A wrapper component that contains elements inside of a `<form>` HTML component and
+allows users to input information.
+
+## When to use
+Use a form when you want users to provide and/or submit information.
+
+## Best practices
+- Provide instructions to help users understand how to complete the form and use form controls.
+- All inputs should have associated and programmatically connected labels. Placeholder text
+should not be used as a replacement for labels.
+- For a required field, if it is not self-explanatory that the field is required
+(e.g. username and password), either add (required) to the label, or use an asterisk "\*". 
+With the use of an asterisk, include a required fields legend above the form inputs: `*Required field`.
+- Use validation and error messages to indicate when a form or field submission fails or requires additional information,
+ensuring that the error messages are associated with the relavent input field/s and announced by screen readers.
+
+## Related components
+
+- Button
+- Checkbox
+- Radio Buttons
+- Search Form
+- Select
+- Text Area Inputs
+- Text Inputs
+
+## Known issues
+
+No known issues.

--- a/stories/components/form/searchForm/SearchForm.mdx
+++ b/stories/components/form/searchForm/SearchForm.mdx
@@ -22,8 +22,9 @@ text to replace labels.
 
 ## Related components
 
+- Form
 - Select
-- Buttons
+- Button
 
 ## Known issues
 

--- a/stories/components/form/select/Select.mdx
+++ b/stories/components/form/select/Select.mdx
@@ -27,7 +27,7 @@ options and submitting data.
 
 ## Related components
 
-No related components.
+- Form
 
 ## Known issues
 

--- a/stories/components/form/textAreaInputs/TextareaInputs.mdx
+++ b/stories/components/form/textAreaInputs/TextareaInputs.mdx
@@ -24,7 +24,7 @@ that’s longer than a single line.
 
 ## Related components
 
-No related components.
+- Form
 
 ## Known issues
 

--- a/stories/components/header/Header.mdx
+++ b/stories/components/header/Header.mdx
@@ -40,7 +40,9 @@ by applying the `header--blue` class:
 The header can contain navigation items. These can be simple links. Use the `header--blue`
 class in this case. On small screens, the navigation items are replaced by a button and
 with a dropdown that shows the links. To see what this looks like, switch to the Canvas
-tab and toggle the "hideMobileNavItems" switch on a mobile view:
+tab and toggle the "hideMobileNavItems" switch on a mobile view. Note that the mobile dropdown
+link should not receive keyboard focus until the dropdown is open. Use Javascript to toggle
+`tabindex="-1"` and `tabindex="0"` on the link elements to handle keyboard focus.
 
 <Story of={stories.withNavItems} />
 

--- a/stories/components/header/dropdownItems.handlebars
+++ b/stories/components/header/dropdownItems.handlebars
@@ -1,7 +1,7 @@
 <nav class="nav-center" aria-label="Main">
   <div class="nav-column">
     <div class="hide-on-lg-up">
-      <button id="nav-toggle" class="btn nav__btn nav__btn--mobile" aria-label="menu" aria-expanded="false">
+      <button id="nav-toggle" class="btn nav__btn--mobile" aria-label="menu" aria-expanded="false">
         <span class="material-icon" aria-hidden="true">menu</span>
       </button>
     </div>

--- a/stories/components/header/navItems.handlebars
+++ b/stories/components/header/navItems.handlebars
@@ -13,8 +13,8 @@
       <span class="material-icon">menu</span>
     </button>
     <ul id="nav-toggle-menu" class="dropdown__list dropdown__list--mobile list--unstyled dropdown__list--navy dropdown__list--slide-left {{#unless showMobileNavItems}}closed{{/unless}}">
-      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="https://raccess.rockarch.org" tabindex="-1">Sign in to RACcess<span class="material-icon">east</span></a></li>
-      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="/list" tabindex="-1">My List<span class="material-icon">east</span></a></li>
+      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="https://raccess.rockarch.org" {{#if showMobileNavItems}}tabindex="0"{{/if}}{{#unless showMobileNavItems}}tabindex="-1"{{/unless}}>Sign in to RACcess<span class="material-icon">east</span></a></li>
+      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="/list" {{#if showMobileNavItems}}tabindex="0"{{/if}}{{#unless showMobileNavItems}}tabindex="-1"{{/unless}}>My List<span class="material-icon">east</span></a></li>
     </ul>
   </div>
 </nav>

--- a/stories/components/header/navItems.handlebars
+++ b/stories/components/header/navItems.handlebars
@@ -1,10 +1,13 @@
 <nav class="nav-right" aria-label="Main">
   <ul class="nav__list show-on-lg-up">
     <li class="nav__item btn--navy">
-      <a class="nav__link" href="https://raccess.rockarch.org/" id="raccess">Sign in to RACcess <span class="material-icon" aria-hidden="true">arrow_right_alt</span></a>
+      <a class="nav__link" href="https://raccess.rockarch.org/" id="raccess">Sign in to RACcess<span class="material-icon" aria-hidden="true">arrow_right_alt</span></a>
     </li>
     <li class="nav__item btn--navy">
-      <a class="nav__link" href="/list/" id="list">My List (146) <span class="material-icon" aria-hidden="true">arrow_right_alt</span></a>
+      <a class="nav__link" href="/list/" id="list">My List (146)<span class="material-icon" aria-hidden="true">arrow_right_alt</span></a>
+    </li>
+    <li class="nav__item btn--navy">
+      <a class="nav__link" href="/about/" id="list">About<span class="material-icon" aria-hidden="true">arrow_right_alt</span></a>
     </li>
   </ul>
 
@@ -15,6 +18,7 @@
     <ul id="nav-toggle-menu" class="dropdown__list dropdown__list--mobile list--unstyled dropdown__list--navy dropdown__list--slide-left {{#unless showMobileNavItems}}closed{{/unless}}">
       <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="https://raccess.rockarch.org" {{#if showMobileNavItems}}tabindex="0"{{/if}}{{#unless showMobileNavItems}}tabindex="-1"{{/unless}}>Sign in to RACcess<span class="material-icon">east</span></a></li>
       <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="/list" {{#if showMobileNavItems}}tabindex="0"{{/if}}{{#unless showMobileNavItems}}tabindex="-1"{{/unless}}>My List<span class="material-icon">east</span></a></li>
+      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="/about" {{#if showMobileNavItems}}tabindex="0"{{/if}}{{#unless showMobileNavItems}}tabindex="-1"{{/unless}}>About<span class="material-icon">east</span></a></li>
     </ul>
   </div>
 </nav>

--- a/stories/global/layout/Layout.mdx
+++ b/stories/global/layout/Layout.mdx
@@ -28,11 +28,12 @@ with  `justify-content: center;`
 Design for a responsive layout by initially creating styles for small screens using a single-column
 layout. Then, enhance using media queries as needed to adjust for medium screens and
 large screens. You can add the SCSS mixins for media queries in local
-site styles along with the screen size breakpoint variables:
+site styles along with the screen size breakpoint variables. Values use em units to also include text zoom
+in the breakpoint calculation (based on a 16px browser root font size):
 ```
 // Breakpoints map
-$break-md: 580px;
-$break-lg: 1024px;
+$break-md: 36.25em;
+$break-lg: 64em;
 
 @mixin md-up {
   @media screen and (min-width: $break-md) { @content; }

--- a/stylesheets/abstracts/_mixins.scss
+++ b/stylesheets/abstracts/_mixins.scss
@@ -43,6 +43,17 @@
 }
 
 /**
+* Defines focus styles that use an inset instead of offset. Used in elements like
+  dropdowns and the search form.
+**/
+@mixin focus-inset {
+  outline: none;
+  box-shadow:
+    inset 0 0 0 2px variables.$white,
+    inset 0 0 0 4px variables.$regal-blue;
+}
+
+/**
 * Adds default transition unless users have set a preference for reduced motion.
 **/
 @mixin transition-default {

--- a/stylesheets/abstracts/_mixins.scss
+++ b/stylesheets/abstracts/_mixins.scss
@@ -35,8 +35,10 @@
 }
 
 // Default focus styles for consistency across browsers and improved accessibility.
+// to work on light or dark backgrounds.
 @mixin focus-default {
-  outline: solid 2px variables.$mortar-grey;
+  box-shadow: 0 0 0 2px variables.$white;
+  outline: 2px solid variables.$regal-blue;
   outline-offset: 2px;
 }
 

--- a/stylesheets/abstracts/_variables.scss
+++ b/stylesheets/abstracts/_variables.scss
@@ -52,8 +52,10 @@ $border-radius-default: 3px;
 $gutters-default: 15px;
 
 // Breakpoints map
-$break-md: 580px;
-$break-lg: 1024px;
+// Uses emm units to ensure breakpoints work with zoom based on
+// 16px base browser root font-size on <html>
+$break-md: 36.25em;  // 580px/16px
+$break-lg: 64em;     // 1024px/16px
 
 // Default transition to be used with @transition-default mixin
 $transition-default: all 0.2s ease;

--- a/stylesheets/base/_helpers.scss
+++ b/stylesheets/base/_helpers.scss
@@ -1,4 +1,5 @@
 @use '../abstracts' as abs;
+@use 'sass:string' as str;
 
 // -----------------------------------------------------------------------------
 // This file contains CSS helper classes.
@@ -107,7 +108,7 @@
 * 1. Defines classes for space amounts 0 to 60.
 */
 
-$sides: (top, bottom, left, right);
+$sides: (top: t, bottom: b, left: l, right: r);
 
 @for $spaceamounts from 0 through 60 { /* 1 */
   @each $space in $spaceamounts {
@@ -118,28 +119,29 @@ $sides: (top, bottom, left, right);
       padding: #{$space}px !important;
     }
 
-    @each $side in $sides {
-      .m#{str-slice($side, 0, 1)}-#{$space} {
+    .mx-#{$space} {
+      margin-left: #{$space}px !important;
+      margin-right: #{$space}px !important;
+    }
+    .my-#{$space} {
+      margin-top: #{$space}px !important;
+      margin-bottom: #{$space}px !important;
+    }
+    .px-#{$space} {
+      padding-left: #{$space}px !important;
+      padding-right: #{$space}px !important;
+    }
+    .py-#{$space} {
+      padding-top: #{$space}px !important;
+      padding-bottom: #{$space}px !important;
+    }
+
+    @each $side, $letter in $sides {
+      .m#{$letter}-#{$space} {
         margin-#{$side}: #{$space}px !important;
       }
-      .p#{str-slice($side, 0, 1)}-#{$space} {
+      .p#{$letter}-#{$space} {
         padding-#{$side}: #{$space}px !important;
-      }
-      .mx-#{$space} {
-        margin-left: #{$space}px !important;
-        margin-right: #{$space}px !important;
-      }
-      .my-#{$space} {
-        margin-bottom: #{$space}px !important;
-        margin-top: #{$space}px !important;
-      }
-      .px-#{$space} {
-        padding-left: #{$space}px !important;
-        padding-right: #{$space}px !important;
-      }
-      .py-#{$space} {
-        padding-bottom: #{$space}px !important;
-        padding-top: #{$space}px !important;
       }
     }
   }

--- a/stylesheets/base/_typography.scss
+++ b/stylesheets/base/_typography.scss
@@ -162,7 +162,7 @@ h3 {
 }
 
 h4 {
-  color: abs.$sandy-orange;
+  color: abs.$yale-blue;
   font-size: 16px;
   margin-bottom: 10px;
   margin-top: 30px;

--- a/stylesheets/components/_alert.scss
+++ b/stylesheets/components/_alert.scss
@@ -37,11 +37,6 @@
   margin: -10px -10px 0 auto;
   order: 3;
   padding: 4px;
-
-  &:hover,
-  &:focus {
-    outline: solid 2px abs.$white;
-  }
 }
 
 /**

--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -104,6 +104,7 @@
 /**
 * Items in a dropdown list styled as buttons. These classes can be used along with
 * specific button color classes.
+* 1. Ensure that button elements in the dropdown are styled to fill the width of the dropdown list.
 **/
 .dropdown__btn {
   border-radius: 0;
@@ -112,6 +113,7 @@
   line-height: 21px;
   margin: 0;
   padding: 10px 14px;
+  width: 100%; /* 1 */
 
   &:focus {
     @include abs.focus-inset;

--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -101,7 +101,6 @@
 /**
 * Items in a dropdown list styled as buttons. These classes can be used along with
 * specific button color classes.
-* 1. Override default focus styles to keep outline inside dropdown menu
 **/
 .dropdown__btn {
   border-radius: 0;
@@ -111,10 +110,8 @@
   margin: 0;
   padding: 10px 14px;
 
-  &:focus { /* 1 */
-    box-shadow: none;
-    outline: 2px solid abs.$white;
-    outline-offset: -4px;
+  &:focus {
+    @include abs.focus-inset;
   }
 
   .material-icon {

--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -48,17 +48,20 @@
 /**
 * Styles for a dropdown list of items used on small screens
 * like the dropdown opened by the navigation menu button.
-* 1. Keeps other page content from covering the dropdown
+* 1. Ensures that the dropdown scrolls on small screen/zoom to prevent
+*    content from being cut off and inaccessible.
+* 2. Keeps other page content from covering the dropdown
 **/
 .dropdown__list--mobile {
   border-radius: 0;
   height: 100%;
   margin-top: 0;
+  overflow-y: auto; /* 1 */
   position: fixed;
   right: 0;
   top: 60px;
   width: 240px;
-  z-index: 999; /* 1 */
+  z-index: 999; /* 2 */
 }
 
 /**

--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -101,6 +101,7 @@
 /**
 * Items in a dropdown list styled as buttons. These classes can be used along with
 * specific button color classes.
+* 1. Override default focus styles to keep outline inside dropdown menu
 **/
 .dropdown__btn {
   border-radius: 0;
@@ -109,6 +110,12 @@
   line-height: 21px;
   margin: 0;
   padding: 10px 14px;
+
+    &:focus { /* 1 */
+      outline: 2px solid abs.$white;
+      outline-offset: -4px;
+      box-shadow:  none;
+  }
 
   .material-icon {
     @include abs.material-icon(21px);
@@ -119,8 +126,4 @@
 
 .dropdown__btn--mobile {
   padding: 12px 24px;
-
-  &:focus {
-    outline-offset: 0;
-  }
 }

--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -111,10 +111,10 @@
   margin: 0;
   padding: 10px 14px;
 
-    &:focus { /* 1 */
-      outline: 2px solid abs.$white;
-      outline-offset: -4px;
-      box-shadow:  none;
+  &:focus { /* 1 */
+    box-shadow: none;
+    outline: 2px solid abs.$white;
+    outline-offset: -4px;
   }
 
   .material-icon {

--- a/stylesheets/components/_inputs.scss
+++ b/stylesheets/components/_inputs.scss
@@ -40,6 +40,7 @@ fieldset {
     font-size: 12px;
     font-weight: abs.$font-weight-bold;
     text-transform: uppercase;
+    margin-bottom: 8px;
   }
 }
 
@@ -50,6 +51,19 @@ fieldset {
   border: 1px solid abs.$night-grey;
   border-radius: 3px;
   padding: 6px;
+
+  &:focus {
+    @include abs.focus-default;
+  }
+}
+
+/**
+* Spacing between inputs and their labels to ensure focus styles don't
+* overlap with the label
+**/
+.input label {
+  margin-bottom: 5px;
+  display: block;
 }
 
 .input__error {
@@ -77,13 +91,14 @@ fieldset {
 * Styles for checkboxes
 /**
 * 1. Keeps text left-aligned when the label stretches multiple lines
-* 2. Moves the actual checkbox off the screen.
-* 3. Expands the label so pseudo elements can be added.
-* 4. Unchecked checkboxes.
-* 5. Checked checkboxes.
-* 6. Transition between checked and unchecked checkboxes.
-* 7. Adds checkmark HTML entity.
-* 8. Ensures appearance and width of checkbox is consistent.
+* 2. Apply default focus styles
+* 3. Moves the actual checkbox off the screen.
+* 4. Expands the label so pseudo elements can be added.
+* 5. Unchecked checkboxes.
+* 6. Checked checkboxes.
+* 7. Transition between checked and unchecked checkboxes.
+* 8. Adds checkmark HTML entity.
+* 9. Ensures appearance and width of checkbox is consistent.
 **/
 
 [type='checkbox'] {
@@ -95,25 +110,27 @@ fieldset {
   display: block; /* 1 */
 }
 
-.checkbox:focus + label::before {
-  outline: 2px solid abs.$mortar-grey;
+.checkbox:focus + label::before { /* 2 */
+  box-shadow: 0 0 0 2px abs.$white;
+  outline: 2px solid abs.$regal-blue;
+  outline-offset: 2px;
 }
 
 .checkbox:not(:checked),
-.checkbox:checked { /* 2 */
+.checkbox:checked { /* 3 */
   left: -9999px;
   position: absolute;
 }
 
 .checkbox:not(:checked) + label,
-.checkbox:checked + label { /* 3 */
+.checkbox:checked + label { /* 4 */
   cursor: pointer;
   padding-left: 30px;
   position: relative;
 }
 
 .checkbox:not(:checked) + label::before,
-.checkbox:checked + label::before { /* 4 */
+.checkbox:checked + label::before { /* 5 */
   content: '';
   height: 16px;
   left: 0;
@@ -124,11 +141,11 @@ fieldset {
 }
 
 .checkbox:not(:checked) + label::after,
-.checkbox:checked + label::after { /* 5 */
+.checkbox:checked + label::after { /* 6 */
   @include abs.transition-default;
 
-  content: '\2713'; /* 7 */
-  font-family: monospace; /* 8 */
+  content: '\2713'; /* 8 */
+  font-family: monospace; /* 9 */
   font-size: 16px;
   height: 16px;
   left: 0;
@@ -139,12 +156,12 @@ fieldset {
   width: 16px;
 }
 
-[type='checkbox']:not(:checked) + label::after { /* 6 */
+[type='checkbox']:not(:checked) + label::after { /* 7 */
   opacity: 0;
   transform: scale(0);
 }
 
-[type='checkbox']:checked + label::after { /* 6 */
+[type='checkbox']:checked + label::after { /* 7 */
   opacity: 1;
   transform: scale(1);
 }
@@ -209,11 +226,11 @@ fieldset {
 }
 
 /**
-* Styles for a group of checkboxes or radio buttons
+* Spacing styles for a group of checkboxes or radio buttons to 
+* ensure focus styles don't overlap with inputs
 **/
-
 fieldset .input-group {
-  margin: 3px 0;
+  margin-bottom: 7px;
 }
 
 /**
@@ -223,7 +240,12 @@ fieldset .input-group {
 .radiobutton {
   margin-right: 3px;
   transform: scale(1.2); /* 1 */
+  vertical-align: middle;
   width: auto;
+
+  &:focus {
+    @include abs.focus-default;
+  }
 }
 
 .radiobutton--blue {

--- a/stylesheets/components/_minimap.scss
+++ b/stylesheets/components/_minimap.scss
@@ -26,7 +26,10 @@ $grid-col-count: 20;
 * Mixin for minimap hit links with a "color" variable argument, including styles
 * on hover, focus, or active events for minimap links.
 * 1. Checkmark for visited links is located in the top right corner of the the box.
-* 2. Styles for checkmark, which is visible via a color change once link is active
+* 2. Use a double-border strategy to ensure sufficient contrast. The outer dark outline 
+*    provides contrast against empty squares, while the inner white border separates it
+*    from the dark active square.
+* 3. Styles for checkmark, which is visible via a color change once link is active
 *    or has been visited.
 **/
 @mixin minimap-hit($color) {
@@ -38,7 +41,8 @@ $grid-col-count: 20;
   text-decoration: none;
 
   @include abs.on-event {
-    border: 2px solid color.adjust($color, $lightness: -22%);
+    border: 1px solid abs.$white; /* 2 */
+    box-shadow: 0 0 0 1px color.adjust($color, $lightness: -22%); /* 2 */
     color: $color;
     outline: none;
     text-decoration: none;
@@ -46,7 +50,7 @@ $grid-col-count: 20;
   }
 
   .material-icon {
-    @include abs.material-icon(12px); /* 2 */
+    @include abs.material-icon(12px); /* 3 */
 
     align-self: flex-start; /* 1 */
   }

--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -103,6 +103,7 @@
 /**
 * Styles for nav that moves flex nav items to a vertical column on small screens.
 * 1. Fill 100% container width on small screens
+* 2. Maintain height of the header on small screens to prevent layout shift when dropdown opens
 **/
 .nav-column {
   display: flex;
@@ -112,6 +113,10 @@
   @include abs.lg-up {
     width: unset; /* 1 */
   }
+}
+
+.nav-column .hide-on-lg-up {
+  min-height: 60px; /* 2 */
 }
 
 /**
@@ -185,10 +190,10 @@
 /**
 * Styles for the navigation button/s that are used to open a dropdown sub-menu of
 * navigation items.
-* 1. Styles that apply only when the dropdown is open based on the aria-expanded
-*    attribute. When aria-expanded=false, these styles do not appear.
-* 2. Positions the border on top of the dropdown when it is open because they
+* 1. Positions the border on top of the dropdown when it is open because they
 *    overlap.
+* 2. Styles that apply only when the dropdown is open based on the aria-expanded
+*    attribute. When aria-expanded=false, these styles do not appear.
 **/
 .nav__btn--dropdown {
   @include nav-item-dropdown;
@@ -200,12 +205,13 @@
   @include abs.lg-up {
     display: inline-block;
     margin: 0 25px;
-    padding: 0 0 13px;
-    position: relative; /* 2 */
-    z-index: 2; /* 2 */
+    padding: 22px 0 21px;
+    position: relative; /* 1 */
+    z-index: 2; /* 1 */
 
     &[aria-expanded='true'] {
-      border-bottom: 8px solid; /* 1 */
+      border-bottom: 8px solid; /* 2 */
+      padding-bottom: 13px;
     }
   }
 

--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -237,6 +237,7 @@
   @include abs.transition-default;
 
   background: abs.$maroon-brown;
+  border: 1px solid abs.$maroon-brown;
   padding: 22px 0 0;
   position: static;
   width: 100%;
@@ -262,14 +263,12 @@
   }
 
   &:focus-within {
-    outline: 2px solid abs.$white;
-    outline-offset: -4px;
+    @include abs.focus-inset;
   }
 }
 
 .nav__link {
-  &:focus,
-  &:focus-within {
+  &:focus {
     outline: none;
     box-shadow: none;
   }

--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -14,6 +14,7 @@
 
   font-size: 13px;
   font-weight: abs.$font-weight-bold;
+  line-height: 1.2;
   letter-spacing: 0.1em;
   margin-bottom: 0;
   text-transform: uppercase;
@@ -120,10 +121,6 @@
 .nav__list {
   margin: 0;
   padding: 0;
-
-  @include abs.lg-up {
-    margin-right: -15px; /* 1 */
-  }
 }
 
 /**
@@ -131,7 +128,7 @@
 **/
 .nav__item {
   border-left: 1px solid abs.$mortar-grey;
-  display: inline-block;
+  display: inline-flex;
 
   @include abs.md-up {
     padding: 0 8px;

--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -15,16 +15,8 @@
   font-size: 13px;
   font-weight: abs.$font-weight-bold;
   letter-spacing: 0.1em;
-  line-height: 60px;
+  margin-bottom: 0;
   text-transform: uppercase;
-
-  @include abs.md-up {
-    line-height: 70px;
-  }
-
-  @include abs.lg-up {
-    line-height: 60px;
-  }
 }
 
 /**
@@ -81,8 +73,10 @@
 
 /**
 * Styles for nav in header. Pushes nav items to the right.
+* 1. Vertically centers nav items within the header flex row.
 **/
 .nav-right {
+  align-items: center; /* 1 */
   display: flex;
   margin-left: auto;
 }
@@ -91,9 +85,10 @@
 * Styles for nav in header.
 * 1. Aligns items to the right on mobile.
 * 2. Aligns items in the center on large screens, with padding-left set as the width of
-* the social icons.
+*    the social icons.
 **/
 .nav-center {
+  align-items: center;
   display: flex;
   justify-content: right; /* 1 */
   width: 100%;
@@ -133,31 +128,44 @@
 
 /**
 * Styles for navigation items and links used within a header.
-* 1. Replace the default focus styles, which don't look good with the header
-*    items, with an underline.
 **/
 .nav__item {
   border-left: 1px solid abs.$mortar-grey;
   display: inline-block;
 
   @include abs.md-up {
-    padding: 0 14px;
-  }
-
-  &:focus-within,
-  &:hover {
-    @include abs.transition-default;
-
-    text-decoration: underline; /* 1 */
+    padding: 0 8px;
   }
 }
 
-.nav__link {
+/**
+* Header nav links (text + icon). inline-flex collapses the link into a single
+* bounding box so the browser draws one unified focus outline rather than
+* separate outlines around the text run and the inline-block icon.
+**/
+.nav__item .nav__link {
   @include header-nav-link;
 
+  align-items: center;
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+
   &:focus {
-    outline: inherit; /* 1 */
+    @include abs.focus-default;
   }
+}
+
+/**
+* Dropdown nav links (title + description paragraphs). Block-level flex column
+* so title and description each have the full dropdown width, preventing
+* wrapping within side-by-side layout.
+**/
+.nav__list-item--dropdown .nav__link {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  text-decoration: none;
 }
 
 /**
@@ -194,19 +202,14 @@
 
   @include abs.lg-up {
     display: inline-block;
-    margin: 20px 25px 0;
+    margin: 0 25px;
     padding: 0 0 13px;
     position: relative; /* 2 */
     z-index: 2; /* 2 */
 
     &[aria-expanded='true'] {
       border-bottom: 8px solid; /* 1 */
-      outline: none; /* 1 */
     }
-  }
-
-  &[aria-expanded='true'] {
-    outline: none; /* 1 */
   }
 
   &:hover {
@@ -247,7 +250,6 @@
 
 /**
 * Styles for the dropdown of navigation list items.
-* 1. Removes link underline and replaces with an outline on focus.
 **/
 .nav__list-item--dropdown {
   height: auto;
@@ -255,14 +257,21 @@
   padding: 12px 28px;
   text-align: left;
 
-  &:hover,
-  &:focus-within {
+  &:hover {
     background: abs.$rust-red;
-    text-decoration: none; /* 1 */
   }
 
   &:focus-within {
-    outline: 1px solid abs.$white; /* 1 */
+    outline: 2px solid abs.$white;
+    outline-offset: -4px;
+  }
+}
+
+.nav__link {
+  &:focus,
+  &:focus-within {
+    outline: none;
+    box-shadow: none;
   }
 }
 
@@ -284,7 +293,6 @@
 * Styles for the menu button that opens a navigation dropdown on small screens.
 * 1. Pushes menu button to the right side of the nav flexbox.
 * 2. Aligns right icon margin with navigation buttons.
-* 3. Removes default outline offset on focus so that the outline stays within the header.
 **/
 .nav__btn--mobile {
   background: unset;
@@ -292,18 +300,7 @@
   margin-left: auto; /* 1 */
   margin-right: 10px; /* 2 */
 
-  &:focus {
-    outline-offset: 0; /* 3 */
-  }
-
   .material-icon {
     @include abs.material-icon(40px);
   }
-}
-
-/**
-* Vertical align button in the center of the header
-**/
-.nav__btn {
-  margin-top: 8px;
 }

--- a/stylesheets/components/_search-form.scss
+++ b/stylesheets/components/_search-form.scss
@@ -43,6 +43,10 @@
   height: 62px;
   padding: 20px;
   width: 100%;
+
+  &:focus {
+    @include abs.focus-inset;
+  }
 }
 
 /**
@@ -58,8 +62,7 @@
   padding: 12px 14px;
 
   &:focus {
-    box-shadow: 0 0 0 1px abs.$white inset;
-    outline: none;
+    @include abs.focus-inset;
   }
 
   .material-icon {
@@ -109,4 +112,8 @@
   height: 62px;
   padding: 20px;
   width: 180px;
+
+  &:focus {
+    @include abs.focus-inset;
+  }
 }

--- a/stylesheets/components/_table-of-contents.scss
+++ b/stylesheets/components/_table-of-contents.scss
@@ -77,7 +77,6 @@
 
 /**
 * Styles to create three table of contents color options, including styles for active links.
-* 1. Add additional padding to link items when the TOC has a title.
 **/
 .toc--neutral {
   background-color: abs.$desert-grey;
@@ -86,10 +85,11 @@
 .toc--neutral .toc__link-item,
 .toc--neutral .toc__title {
   color: abs.$night-grey;
+  border: 1px solid abs.$desert-grey;
 }
 
 .toc--neutral .active {
-  background-color: abs.$rust-red;
+  background-color: abs.$umber-brown;
   color: abs.$desert-grey;
 }
 
@@ -100,6 +100,7 @@
 .toc--blue .toc__link-item,
 .toc--blue .toc__title {
   color: abs.$regal-blue;
+  border: 1px solid abs.$solitude-blue;
 }
 
 .toc--blue .active {
@@ -113,19 +114,26 @@
 
 .toc--orange .toc__link-item,
 .toc--orange .toc__title {
-  color: abs.$white;
+  color: abs.$desert-grey;
+  border: 1px solid abs.$umber-brown;
+}
+
+.toc--orange .active {
+  background-color: abs.$desert-grey;
+  color: abs.$umber-brown;
+}
+
+/**
+* Styles for inset table of contents focus styles to work with all background colors
+* 1. Add additional padding to link items when the TOC has a title.
+**/
+.toc__title:focus,
+.toc__link-item:focus {
+  @include abs.focus-inset;
+
+  border-color: abs.$regal-blue;
 }
 
 .toc__title + div .toc__link-item {
   padding-left: 40px; /* 1 */
-}
-
-.toc--orange .toc__link-item:focus,
-.toc--orange .toc__title:focus {
-  outline: none;
-  text-decoration: underline;
-}
-
-.toc--orange .active {
-  border: abs.$white 2px solid;
 }

--- a/stylesheets/layout/_header.scss
+++ b/stylesheets/layout/_header.scss
@@ -105,10 +105,10 @@
   flex-flow: column wrap;
   margin-right: auto;
   padding-left: 15px;
-  place-content: center center;
   z-index: 3;
 
   @include abs.lg-up {
+    align-items: center;
     flex-direction: row;
     justify-content: flex-start;
     padding-left: 65px;

--- a/stylesheets/layout/_header.scss
+++ b/stylesheets/layout/_header.scss
@@ -17,7 +17,7 @@
 
 /**
 * Header title mixin
-*1. Assumes title is always a link and underlines on event
+* 1. Assumes title is always a link and underlines on hover
 **/
 @mixin header-title {
   @include header-text;
@@ -31,8 +31,7 @@
     font-size: 15px;
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     text-decoration: underline; /* 1 */
   }
 }
@@ -50,14 +49,20 @@
 /**
 * Styles for header. Header is not fixed/sticky by default,
 * so custom styles are required to implement that.
+* 1. Vertically center all header content (brand, nav, social icons) within
+*    the header height.
 **/
-
 .header {
   min-height: 60px;
   width: 100%;
 
   .wrapper {
+    align-items: center; /* 1 */
     min-height: 60px;
+  }
+
+  .container {
+    align-items: center; /* 1 */
   }
 }
 
@@ -84,11 +89,6 @@
   a,
   button {
     color: abs.$white;
-  }
-
-  button:focus,
-  .social-icons a:focus {
-    outline-color: abs.$white;
   }
 
   svg g,
@@ -119,6 +119,7 @@
   @include header-title;
 
   margin: 0 10px 5px 0;
+  padding: 2px;
 
   @include abs.lg-up {
     margin: 0 10px 0 0;

--- a/test/partials/_test_helpers.scss
+++ b/test/partials/_test_helpers.scss
@@ -16,6 +16,22 @@
   }
 }
 
+@include describe('The focus-inset mixin') {
+  @include it('Sets inset focus styles') {
+    @include assert {
+      @include output {
+        @include focus-inset();
+      }
+      @include expect {
+        outline: none;
+        box-shadow:
+          inset 0 0 0 2px $white,
+          inset 0 0 0 4px $regal-blue;
+      }
+    }
+  }
+}
+
 @include describe('The transition-default mixin') {
   @include it('Sets default transition unless users have set a preference for reduced motion') {
     @include assert {

--- a/test/partials/_test_helpers.scss
+++ b/test/partials/_test_helpers.scss
@@ -8,7 +8,8 @@
         @include focus-default();
       }
       @include expect {
-        outline: solid 2px $mortar-grey;
+        box-shadow: 0 0 0 2px $white;
+        outline: 2px solid $regal-blue;
         outline-offset: 2px;
       }
     }


### PR DESCRIPTION
Address accessibility audit remediation issues (issues are detailed in internal audit documentation). Also makes updates to better optimize spacing helper classes and address deprecation of `str-slice`.

## Audit issues 1, 2, 253
**Issue**: Outline focus styles in header, secondary footer, and modal close buttons don't have sufficient color contrast and/or don't have a sufficient focus style (underline is not ideal).
**Fix**: Updated the default focus styles in abstracts/_mixins.scss to include both a white box shadow and a dark offset outline, as is a recommended approach for flexible design systems to handle focus on light and dark backgrounds without a lot of component-level customization. I also changed the dark outline to regal-blue to better align with our designs (the existing gray is something I designed during the development of DIMES, but never had designer input). 

This work also included adding a new default `focus-inset` mixin to handle focus in components like dropdowns and table of contents where we want to better control focus outlines that overlap other content.

Components impacts: all components _except_ alert, hero, and minimap

## Audit issue 113
**Issue:** Minimap focus styles don't have sufficient contrast against all possible backgrounds.
**Fix**: Updated to use a double border strategy of both white and the darker color to contrast with all possible background colors

## Audit issue 3 
**Issue:** h4 color does not have sufficient contrast with white background. 
**Fix:** Changed to yale-blue. See h4 in storybook typography documentation.

## Audit issue 4 
**Issue:** At 200% text zoom, the header with dropdown items has overlapping text. 
**Fix**: Made global breakpoint variable values use em units instead of pixels so that text zoom (based on font size) will trigger the breakpoints. This is hard to test in Storybook, need to double check this in individual site implementation.

## Audit issue 5
**Issue:** A list of cards should also include headings for consistent screen reader UX. 
**Fix:** Updated the style guide to reflect this change (implement in DIMES and the Library Site).

## Audit issue 7
**Issue:** Default focus styles for select element do not have sufficient contrast with white background. 
**Fix:** Updated the library focus styles for all form inputs to standardize and ensure sufficient contrast. To test: tab through form input stories in Storybook to see focus styles.

## Audit issue 251
**Issue:** Orange table of contents focus styles use underlines instead of outlines for focus styles. 
**Fix**: Updated all table of contents focus styles to use focus-inset styles. See Table of Contents component in storybook.

## Audit issues 23, 32 
**Issue:** On zoom/small screens, fixed header nav dropdown prevents access to all links. 
**Fix:** Added a scrollbar to the dropdown to ensure all links can appear/receive focus. This is hard to recreate in Storybook, but I applied these styles to the blog site locally to test.

## Audit issue 8 
**Issue:** Define the required (*) asterisks in form labels. 
**Fix:** Added form documentation clarifying the best practices for documenting required form fields. See Form/All Form Components in storybook.

## Notes for implementation in individual sites
- Check focus styles carefully when implementing to ensure any local focus styles work with these updates ((backstopjs visual regression isn't set up to test focus style changes))
- Check breakpoint change from pxs to ems to ensure no unintended behaviour.
- Updated required form fields according to the documented best practices