### PR TITLE
Simplify dropdown component

### DIFF
--- a/stories/components/dropdown/Dropdown.mdx
+++ b/stories/components/dropdown/Dropdown.mdx
@@ -10,17 +10,18 @@ selection. Use a button to open and close the dropdown menu.
 
 ## When to use
 
-This component can be used for navigation or command menus where there are typically 5 or more items. Use in mobile
-contexts when actions are collapsed into a single menu. In cases where users will select one or more
+This component can be used for navigation or disclosure menus where there are typically 5 or more items. Use in mobile
+contexts when actions are collapsed into a single dropdown menu. In cases where users will select one or more
 options from a list that do not initiate an action, use the Select component instead.
+
+Note: This component is not a menu that uses ARIA role="menu" applied, which is more commonly used with operating system
+menus and menubars.
 
 ## Best practices
 
 - Use descriptive item labels so that users understand what selecting the item will do.
-- Keep menu items to a single line of text.
+- Keep dropdown items to a single line of text.
 - Sort the list in a logical order with the most commonly selected items at the top.
-- For mobile site navigation in the header, use an unordered list element with the links as list items, and do not
-use the `menu` or `menuitem` aria roles . Refer to the header styles for more details.
 
 ## Related components
 
@@ -32,7 +33,13 @@ use the `menu` or `menuitem` aria roles . Refer to the header styles for more de
 No known issues.
 
 ## Basic implementation
-Use javascript to enable the button to open and close the dropdown menu. To see what this looks
-like, switch to the Canvas tab and toggle the "showDropdownItems" switch.
+Use javascript to:
+- Enable the button to open and close the dropdown menu
+- Toggle aria-expanded values to `true` or `false` on the button.
+- Toggle the closed/open CSS classes on the `dropdown__list` element
+- Implement handling Esc and user focus outside of the dropdown to close the dropdown
+- Implement Esc setting focus back to the button control.
+
+To open/close the dropdown, switch to the Canvas tab and toggle the "showDropdownItems" switch.
 
 <Story of={stories.basic} />

--- a/stories/components/dropdown/dropdown.handlebars
+++ b/stories/components/dropdown/dropdown.handlebars
@@ -1,42 +1,46 @@
 <div class="dropdown">
-  <button class="btn btn--orange btn--md" {{#if showDropdownItems}}aria-expanded="true"{{else}}aria-expanded="false"{{/if}} 
-  aria-haspopup="true" tabindex="0">
+  <button class="btn btn--orange btn--md" {{#if showDropdownItems}}aria-expanded="true"{{else}}aria-expanded="false"{{/if}}>
     <span class="material-icon material-icon--space-after" aria-hidden="true">{{iconBefore}}</span>
     {{buttonText}}
   </button>
   {{#if showDropdownItems}}
-  <div class="dropdown__list dropdown__list--orange dropdown__list--slide-down open" role="menu">
-    <a id="menu-item-0" class="btn btn--orange dropdown__btn dropdown__item--orange"
-      href={{linkTarget}}
-      tabindex="0" role="menuitem">
-      <span class="material-icon" aria-hidden="true">account_balance</span>
-      Schedule a Visit
-    </a>
-    <a id="menu-item-1" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="0" role="menuitem">
-      <span class="material-icon" aria-hidden="true">local_library</span>
-      Request Items in Reading Room
-    </a>
-    <a id="menu-item-2" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="0" role="menuitem">
-      <span class="material-icon" aria-hidden="true">content_copy</span>
+  <ul class="list--unstyled dropdown__list dropdown__list--orange dropdown__list--slide-down open">
+    <li>
+      <a class="btn btn--orange dropdown__btn dropdown__item--orange" href={{linkTarget}}>
+        <span class="material-icon" aria-hidden="true">account_balance</span>
+        Schedule a Visit
+      </a>
+    </li>
+    <li>
+      <a class="btn btn--orange dropdown__btn dropdown__item--orange" href={{linkTarget}}>
+        <span class="material-icon" aria-hidden="true">local_library</span>
+        Request Items in Reading Room
+      </a>
+    </li>
+    <li>
+      <a class="btn btn--orange dropdown__btn dropdown__item--orange" href={{linkTarget}}>
+        <span class="material-icon" aria-hidden="true">content_copy</span>
       Request Copies
       </a>
-    <a id="menu-item-3" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="0" role="menuitem">
-      <span class="material-icon" aria-hidden="true">email</span>
-      Email List
-    </a>
-    <a id="menu-item-4" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="0" role="menuitem">
-      <span class="material-icon" aria-hidden="true">get_app</span>
-      Download as .csv
-    </a>
-    <button id="menu-item-5" class="btn btn--orange dropdown__btn dropdown__item--orange" 
-      tabindex="0" role="menuitem">
-      <span class="material-icon" aria-hidden="true">delete</span>
-      Remove All Items
-    </button>
-  </div>
+    </li>
+    <li>
+      <a class="btn btn--orange dropdown__btn dropdown__item--orange" href={{linkTarget}}>
+        <span class="material-icon" aria-hidden="true">email</span>
+        Email List
+      </a>
+    </li>
+    <li>
+      <button id="button-control-2" class="btn btn--orange dropdown__btn dropdown__item--orange" type="button">
+        <span class="material-icon" aria-hidden="true">get_app</span>
+        Download as .csv
+      </button>
+    </li>
+    <li>
+      <button id="button-control-2" class="btn btn--orange dropdown__btn dropdown__item--orange" type="button">
+        <span class="material-icon" aria-hidden="true">delete</span>
+        Remove All Items
+      </button>
+    </li>
+  </ul>
   {{/if}}
 </div>

--- a/stories/components/header/Header.mdx
+++ b/stories/components/header/Header.mdx
@@ -40,9 +40,7 @@ by applying the `header--blue` class:
 The header can contain navigation items. These can be simple links. Use the `header--blue`
 class in this case. On small screens, the navigation items are replaced by a button and
 with a dropdown that shows the links. To see what this looks like, switch to the Canvas
-tab and toggle the "hideMobileNavItems" switch on a mobile view. Note that the mobile dropdown
-link should not receive keyboard focus until the dropdown is open. Use Javascript to toggle
-`tabindex="-1"` and `tabindex="0"` on the link elements to handle keyboard focus.
+tab and toggle the "hideMobileNavItems" switch on a mobile view.
 
 <Story of={stories.withNavItems} />
 

--- a/stories/components/header/navItems.handlebars
+++ b/stories/components/header/navItems.handlebars
@@ -12,8 +12,8 @@
   </ul>
 
   <div class="dropdown hide-on-lg-up">
-    <button id="nav-toggle" class="btn btn--navy nav__btn--mobile closed" aria-expanded="false">
-      <span class="material-icon">menu</span>
+    <button id="nav-toggle" class="btn btn--navy nav__btn--mobile closed" aria-label="menu" aria-expanded="false">
+      <span class="material-icon" aria-hidden="true">menu</span>
     </button>
     <ul id="nav-toggle-menu" class="dropdown__list dropdown__list--mobile list--unstyled dropdown__list--navy dropdown__list--slide-left {{#unless showMobileNavItems}}closed{{/unless}}">
       <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="https://raccess.rockarch.org">Sign in to RACcess<span class="material-icon">east</span></a></li>

--- a/stories/components/header/navItems.handlebars
+++ b/stories/components/header/navItems.handlebars
@@ -16,9 +16,9 @@
       <span class="material-icon">menu</span>
     </button>
     <ul id="nav-toggle-menu" class="dropdown__list dropdown__list--mobile list--unstyled dropdown__list--navy dropdown__list--slide-left {{#unless showMobileNavItems}}closed{{/unless}}">
-      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="https://raccess.rockarch.org" {{#if showMobileNavItems}}tabindex="0"{{/if}}{{#unless showMobileNavItems}}tabindex="-1"{{/unless}}>Sign in to RACcess<span class="material-icon">east</span></a></li>
-      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="/list" {{#if showMobileNavItems}}tabindex="0"{{/if}}{{#unless showMobileNavItems}}tabindex="-1"{{/unless}}>My List<span class="material-icon">east</span></a></li>
-      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="/about" {{#if showMobileNavItems}}tabindex="0"{{/if}}{{#unless showMobileNavItems}}tabindex="-1"{{/unless}}>About<span class="material-icon">east</span></a></li>
+      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="https://raccess.rockarch.org">Sign in to RACcess<span class="material-icon">east</span></a></li>
+      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="/list">My List<span class="material-icon">east</span></a></li>
+      <li><a class="btn btn--navy dropdown__btn dropdown__btn--mobile" href="/about">About<span class="material-icon">east</span></a></li>
     </ul>
   </div>
 </nav>

--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -17,6 +17,7 @@
 /**
 * Styles for a dropdown list or menu of items, typically used on small screens.
 * 1. The negative z-index value places the dropdown list under all other
+* 2. Hide the dropdown when it is closed to prevent it from being focusable and accessible to screen readers.
 * values until it is opened.
 **/
 .dropdown__list {
@@ -30,11 +31,13 @@
 
   &.open {
     opacity: 1;
+    visibility: visible; /* 2 */
     z-index: 1000; /* 1 */
   }
 
   &.closed {
     opacity: 0;
+    visibility: hidden; /* 2 */
   }
 }
 


### PR DESCRIPTION
Fix #298 

Simplify the dropdown component to remove the aria role="menu" pattern and follow a [disclosure nav pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation/).

- Places the dropdown items as list items in a `<ul>`
- Removes tabindex for focus management in favor of `visibility: "hidden"` and `visibility: "visible"` in the dropdown styles.

For site implementation:
- DIMES should also simplify it's use of dropdowns and replace the aria menu role approach with this one for both header nav and the My List actions dropdown ([see DIMES PR 851](https://github.com/RockefellerArchiveCenter/dimes/pull/851))
- Remove custom javascript in sites that add/remove tabindex values