### PR TITLE
Fixes for style library implementation in DIMES

### DIFF
--- a/stylesheets/base/_base.scss
+++ b/stylesheets/base/_base.scss
@@ -39,7 +39,7 @@ body {
  * not sufficient based on background color or other factors, they can be overridden at the
  * component level.
  */
-button:focus,
-a:focus {
+button:focus-visible,
+a:focus-visible {
   @include abs.focus-default;
 }

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -112,6 +112,7 @@
   &:hover,
   &:focus {
     background-color: color.adjust(abs.$yale-blue, $lightness: -10%);
+    border-color: color.adjust(abs.$yale-blue, $lightness: -10%);
     color: abs.$white;
   }
 }
@@ -132,6 +133,7 @@
   &:hover,
   &:focus {
     background-color: color.adjust(abs.$regal-blue, $lightness: 10%);
+    border-color: color.adjust(abs.$regal-blue, $lightness: 10%);
     color: abs.$white;
   }
 }
@@ -172,6 +174,7 @@
   &:hover,
   &:focus {
     background-color: color.adjust(abs.$dark-grey, $lightness: -5%);
+    border-color: color.adjust(abs.$dark-grey, $lightness: -5%);
     color: abs.$black;
   }
 }

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -112,7 +112,6 @@
   &:hover,
   &:focus {
     background-color: color.adjust(abs.$yale-blue, $lightness: -10%);
-    border-color: color.adjust(abs.$yale-blue, $lightness: -10%);
     color: abs.$white;
   }
 }
@@ -133,7 +132,6 @@
   &:hover,
   &:focus {
     background-color: color.adjust(abs.$regal-blue, $lightness: 10%);
-    border-color: color.adjust(abs.$regal-blue, $lightness: 10%);
     color: abs.$white;
   }
 }
@@ -144,7 +142,6 @@
   &:hover,
   &:focus {
     background-color: color.adjust(abs.$umber-brown, $lightness: -10%);
-    border-color: color.adjust(abs.$umber-brown, $lightness: -10%);
     color: abs.$desert-grey;
   }
 }
@@ -175,7 +172,6 @@
   &:hover,
   &:focus {
     background-color: color.adjust(abs.$dark-grey, $lightness: -5%);
-    border-color: color.adjust(abs.$dark-grey, $lightness: -5%);
     color: abs.$black;
   }
 }

--- a/stylesheets/components/_button.scss
+++ b/stylesheets/components/_button.scss
@@ -144,6 +144,7 @@
   &:hover,
   &:focus {
     background-color: color.adjust(abs.$umber-brown, $lightness: -10%);
+    border-color: color.adjust(abs.$umber-brown, $lightness: -10%);
     color: abs.$desert-grey;
   }
 }

--- a/stylesheets/components/_minimap.scss
+++ b/stylesheets/components/_minimap.scss
@@ -26,9 +26,7 @@ $grid-col-count: 20;
 * Mixin for minimap hit links with a "color" variable argument, including styles
 * on hover, focus, or active events for minimap links.
 * 1. Checkmark for visited links is located in the top right corner of the the box.
-* 2. Use a double-border strategy to ensure sufficient contrast. The outer dark outline 
-*    provides contrast against empty squares, while the inner white border separates it
-*    from the dark active square.
+* 2. Don't override default link focus styles, but add additional styles to make the hit more visible on hover.
 * 3. Styles for checkmark, which is visible via a color change once link is active
 *    or has been visited.
 **/
@@ -41,10 +39,8 @@ $grid-col-count: 20;
   text-decoration: none;
 
   @include abs.on-event {
-    border: 1px solid abs.$white; /* 2 */
-    box-shadow: 0 0 0 1px color.adjust($color, $lightness: -22%); /* 2 */
+    border: 2px solid color.adjust($color, $lightness: -22%); /* 2 */
     color: $color;
-    outline: none;
     text-decoration: none;
     transform: scale(1.3);
   }

--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -153,7 +153,7 @@
   gap: 4px;
   padding: 4px;
 
-  &:focus {
+  &:focus-visible {
     @include abs.focus-default;
   }
 }

--- a/stylesheets/layout/_header.scss
+++ b/stylesheets/layout/_header.scss
@@ -128,6 +128,8 @@
 
 .header__brand-subtitle {
   @include header-subtitle;
+
+  padding-left: 2px;
 }
 
 /**


### PR DESCRIPTION
Adjustments to styles based on implementation in DIMES:
- For default focus styles, use `focus-visible` instead of `focus` to improve the click interaction for mouse users (for example, avoid a focus outline that appears briefly when the user clicks a link)
- Adjust hover/focus styles for minimap squares to fully address color contrast issues (there were still problems with sufficient color contrast against adjacent colored squares)
- Fix slight header text misalignment