### PR TITLE
Bug fix: revert change for nav list dropdown focus

### DIFF
--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -269,7 +269,7 @@
     background: abs.$rust-red;
   }
 
-  &:focus-visible {
+  &:focus-within {
     @include abs.focus-inset;
   }
 }


### PR DESCRIPTION
Corrects focus styles, which are otherwise not visible.