### PR TITLE
Fix mobile nav styles and functionality

### DIFF
--- a/stylesheets/components/_dropdown.scss
+++ b/stylesheets/components/_dropdown.scss
@@ -57,7 +57,7 @@
 **/
 .dropdown__list--mobile {
   border-radius: 0;
-  height: 100%;
+  height: calc(100vh - 60px); /* 1 */
   margin-top: 0;
   overflow-y: auto; /* 1 */
   position: fixed;

--- a/stylesheets/components/_nav.scss
+++ b/stylesheets/components/_nav.scss
@@ -200,7 +200,7 @@
 
   background: unset;
   border: 0;
-  padding: 15px 20px 15px 0;
+  padding: 15px 20px;
 
   @include abs.lg-up {
     display: inline-block;


### PR DESCRIPTION
Bug fixes:
- Standardize padding around dropdown nav button so that focus outline is aligned
- Fix mobile nav dropdown so that it actually scrolls down instead of extending off the screen