### PR TITLE
fix: improve search form and alert styles accessibility

### DIFF
--- a/stories/components/form/searchForm/SearchForm.mdx
+++ b/stories/components/form/searchForm/SearchForm.mdx
@@ -32,6 +32,9 @@ No known issues.
 
 ## Basic implementation
 
+In the default implementation, the label for the search input is hidden using the
+`visually-hidden` class. The label is still available to screen readers.
+
 <Story of={stories.basic} />
 
 ## With additional controls
@@ -45,14 +48,3 @@ Or included as an inline element:
 
 <Story of={stories.withInlineControls} />
 
-## With hidden elements
-
-It is possible to hide the label for the search input by adding the `visually-hidden` class.
-The label will still be available to screen readers:
-
-<Story of={stories.noLabel} />
-
-In cases where a search is automatically executed on keydown or other event, the
-search input button can be hidden as well:
-
-<Story of={stories.noButton} />

--- a/stories/components/form/searchForm/SearchForm.stories.js
+++ b/stories/components/form/searchForm/SearchForm.stories.js
@@ -12,20 +12,6 @@ export const basic = () => Search({
   button: true
 })
 
-export const noButton = () => Search({
-  hideLabel: false,
-  controlsBlock: false,
-  controlsInline: false,
-  button: false
-})
-
-export const noLabel = () => Search({
-  hideLabel: true,
-  controlsBlock: false,
-  controlsInline: false,
-  button: true
-})
-
 export const withBlockControls = () => Search({
   hideLabel: false,
   controlsBlock: true,

--- a/stories/components/form/searchForm/searchForm.handlebars
+++ b/stories/components/form/searchForm/searchForm.handlebars
@@ -2,7 +2,7 @@
   <div class="search">
     <div class="input-group__search">
       <div class="input__search">
-        <label for="query" class="{{#if hideLabel}}visually-hidden {{/if}}">Enter a search term</label>
+        <label for="query" class="visually-hidden">Enter a search term</label>
         <input type="search" id="query" name="query" placeholder="Search..." maxlength="255" size="60" required>
       </div>
       {{#if controlsInline}}
@@ -19,9 +19,7 @@
         </div>
       </div>
       {{/if}}
-      {{#if button}}
       <button type="submit" class="btn btn--orange search__submit-btn" aria-label="submit search"><span class="material-icon" aria-hidden="true">search</span></button>
-      {{/if}}
     </div>
     {{#if controlsBlock}}
     <div class="input-group__search-controls">

--- a/stylesheets/components/_alert.scss
+++ b/stylesheets/components/_alert.scss
@@ -51,7 +51,11 @@
 * Optional alert icon.
 **/
 .alert__icon {
-  @include abs.material-icon(75px, normal);
+  @include abs.material-icon(32px, normal);
+
+  @include abs.md-up {
+    @include abs.material-icon(75px, normal);
+  }
 
   align-self: start;
   padding-right: 10px;

--- a/stylesheets/components/_search-form.scss
+++ b/stylesheets/components/_search-form.scss
@@ -88,7 +88,7 @@
   width: 100%; /* 3 */
 
   @include abs.md-up {
-    padding-top: 0px;
+    padding-top: 0;
     width: auto;
   }
 }
@@ -137,7 +137,9 @@
 /**
 * Restore default order of search input, select, and button for desktop.
 **/
-.input__search, .search__submit-btn, .select__search--wrapper {
+.input__search,
+.search__submit-btn,
+.select__search--wrapper {
   @include abs.md-up {
     order: 0;
   }
@@ -151,8 +153,9 @@
   flex-wrap: wrap;
   justify-content: flex-start;
   margin-top: 10px;
+}
 
-  .select__search--wrapper {
-    padding-top: 0px;
-  }
+.input-group__search-controls,
+.select__search--wrapper {
+  padding-top: 0;
 }

--- a/stylesheets/components/_search-form.scss
+++ b/stylesheets/components/_search-form.scss
@@ -12,35 +12,37 @@
   flex-wrap: wrap;
 }
 
+/**
+* Defines layout styles for the search input, select, and button container.
+**/
 .input-group__search {
   display: flex;
+  flex-wrap: wrap;
   width: 100%;
 }
 
-.input-group__search-controls {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  margin-top: 20px;
-}
-
+/**
+* Defines styles for the search input container.
+* 1. Prevents button from wrapping to a new line when the search input is resized.
+**/
 .input__search {
+  flex: 1 1 0px; /* 1 */
   width: 100%;
 }
 
 /**
 * Defines styles for search input box and associated text.
-* 1. Removes rounded corners on iOS
-* 2. Changes font-size from the standard input-text mixin
+* 1. Removes default iOS appearance (rounded corners).
+* 2. Sets fixed height for the input.
 **/
 .input__search input {
   @include abs.input-text;
 
   appearance: none; /* 1 */
   border: 1px solid abs.$night-grey;
-  border-radius: 0; /* 1 */
-  font-size: 18px; /* 2 */
-  height: 62px;
+  border-radius: 0;
+  font-size: 18px;
+  height: 62px; /* 2 */
   padding: 20px;
   width: 100%;
 
@@ -52,13 +54,15 @@
 /**
 * Defines styles for button associated with the search-form component.
 * 1. Align button with search input box instead of label.
+* 2. Merges the border with the input field.
+* 3. Places button after input in visual order.
 **/
-
 .search__submit-btn {
   align-self: flex-end; /* 1 */
   border-color: abs.$rust-red;
   border-radius: 0;
-  margin-left: -1px;
+  margin-left: -1px; /* 2 */
+  order: 2; /* 3 */
   padding: 12px 14px;
 
   &:focus {
@@ -71,35 +75,37 @@
 }
 
 /**
-* Defines styles for select.
+* Defines styles for select wrapper.
 * 1. Align select with search input box instead of label
-* 2. Do not display on small screens
+* 2. Forces visual order to appear last (below input and button).
+* 3. Forces 100% width on mobile to force a line break.
 **/
 .select__search--wrapper {
   align-self: flex-end; /* 1 */
-  display: none; /* 2 */
-  position: relative;
+  display: flex;
+  order: 3; /* 2 */
+  padding-top: 10px;
+  width: 100%; /* 3 */
 
   @include abs.md-up {
-    display: inline-block; /* 2 */
-  }
-
-  /**
-  * Specify size and placement of icon to replace default select expand arrow
-  **/
-  .material-icon {
-    @include abs.material-icon(20px);
-
-    position: absolute;
-    right: 22px;
-    top: 20px;
+    padding-top: 0px;
+    width: auto;
   }
 }
 
 /**
-* Defines styles for select and associated text. Note that with the native select element,
-* there is no ability to style the select options.
-* 1. Remove the default select expand arrow, which is replaced with an icon in the html.
+* Defines styles for select and associated text.
+* 1. Establishes positioning context for the absolute icon.
+**/
+.select__search {
+  position: relative; /* 1 */
+  width: 180px;
+}
+
+/**
+* Defines styles for the select element itself.
+* 1. Hides the default expand arrow.
+* 2. Sets fixed height to match input.
 **/
 .select__search select {
   @include abs.input-text;
@@ -109,11 +115,44 @@
   border: 1px solid abs.$night-grey;
   border-radius: 0;
   font-size: 16px;
-  height: 62px;
+  height: 62px; /* 2 */
   padding: 20px;
-  width: 180px;
 
   &:focus {
     @include abs.focus-inset;
+  }
+}
+
+/**
+* Specify size and placement of icon to replace default select expand arrow.
+**/
+.select__search .material-icon {
+  @include abs.material-icon(20px);
+
+  position: absolute;
+  right: 10px;
+  top: 20px;
+}
+
+/**
+* Restore default order of search input, select, and button for desktop.
+**/
+.input__search, .search__submit-btn, .select__search--wrapper {
+  @include abs.md-up {
+    order: 0;
+  }
+}
+
+/**
+* Styles for controls styled as a block element (not inline).
+**/
+.input-group__search-controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  margin-top: 10px;
+
+  .select__search--wrapper {
+    padding-top: 0px;
   }
 }

--- a/stylesheets/components/_search-form.scss
+++ b/stylesheets/components/_search-form.scss
@@ -155,7 +155,6 @@
   margin-top: 10px;
 }
 
-.input-group__search-controls,
-.select__search--wrapper {
+.input-group__search-controls .select__search--wrapper {
   padding-top: 0;
 }

--- a/stylesheets/components/_search-form.scss
+++ b/stylesheets/components/_search-form.scss
@@ -23,17 +23,20 @@
 
 /**
 * Defines styles for the search input container.
-* 1. Prevents button from wrapping to a new line when the search input is resized.
+* 1. Aligns items when text is resized.
+* 2. Prevents button from wrapping to a new line when the search input is resized.
 **/
 .input__search {
-  flex: 1 1 0px; /* 1 */
+  align-items: stretch; /* 1 */
+  display: flex; /* 1 */
+  flex: 1 1 0px; /* 2 */
   width: 100%;
 }
 
 /**
 * Defines styles for search input box and associated text.
 * 1. Removes default iOS appearance (rounded corners).
-* 2. Sets fixed height for the input.
+* 2. Sets min height but allows height to grow with text resizing.
 * 3. Places input first in visual order.
 **/
 .input__search input {
@@ -43,8 +46,9 @@
   border: 1px solid abs.$night-grey;
   border-radius: 0;
   font-size: 18px;
-  height: 62px; /* 2 */
-  order: 1;
+  height: auto; /* 2 */
+  min-height: 63px; /* 2 */
+  order: 1; /* 3 */
   padding: 20px;
   width: 100%;
 
@@ -56,15 +60,18 @@
 /**
 * Defines styles for button associated with the search-form component.
 * 1. Align button with search input box instead of label.
-* 2. Merges the border with the input field.
-* 3. Places button after input in visual order.
+* 2. Sets min height but allows height to grow with text resizing.
+* 3. Merges the border with the input field.
+* 4. Places button after input in visual order.
 **/
 .search__submit-btn {
   align-self: flex-end; /* 1 */
   border-color: abs.$rust-red;
   border-radius: 0;
-  margin-left: -1px; /* 2 */
-  order: 2; /* 3 */
+  height: auto; /* 2 */
+  margin-left: -1px; /* 3 */
+  min-height: 63px; /* 2 */
+  order: 2; /* 4 */
   padding: 12px 14px;
 
   &:focus {
@@ -100,17 +107,21 @@
 
 /**
 * Defines styles for select and associated text.
-* 1. Establishes positioning context for the absolute icon.
+* 1. Aligns items when text is resized.
+* 2. Establishes positioning context for the absolute icon.
+* 3. Sets minimum width using ems to prevent select from collapsing when options are long with text resize.
 **/
 .select__search {
-  position: relative; /* 1 */
-  width: 180px;
+  align-items: stretch; /* 1 */
+  display: flex; /* 1 */
+  position: relative; /* 2 */
+  min-width: 11em; /* 3 */
 }
 
 /**
 * Defines styles for the select element itself.
 * 1. Hides the default expand arrow.
-* 2. Sets fixed height to match input.
+* 2. Sets min height but allows height to grow with text resizing.
 **/
 .select__search select {
   @include abs.input-text;
@@ -120,7 +131,8 @@
   border: 1px solid abs.$night-grey;
   border-radius: 0;
   font-size: 16px;
-  height: 62px; /* 2 */
+  height: auto; /* 2 */
+  min-height: 63px; /* 2 */
   padding: 20px;
 
   &:focus {

--- a/stylesheets/components/_search-form.scss
+++ b/stylesheets/components/_search-form.scss
@@ -34,6 +34,7 @@
 * Defines styles for search input box and associated text.
 * 1. Removes default iOS appearance (rounded corners).
 * 2. Sets fixed height for the input.
+* 3. Places input first in visual order.
 **/
 .input__search input {
   @include abs.input-text;
@@ -43,6 +44,7 @@
   border-radius: 0;
   font-size: 18px;
   height: 62px; /* 2 */
+  order: 1;
   padding: 20px;
   width: 100%;
 
@@ -79,15 +81,18 @@
 * 1. Align select with search input box instead of label
 * 2. Forces visual order to appear last (below input and button).
 * 3. Forces 100% width on mobile to force a line break.
+* 4. Removes extra margin when select is inline with input and button.
 **/
 .select__search--wrapper {
   align-self: flex-end; /* 1 */
   display: flex;
   order: 3; /* 2 */
   padding-top: 10px;
+  margin-left: 0;
   width: 100%; /* 3 */
 
-  @include abs.md-up {
+  @include abs.lg-up {
+    margin-left: -1px; /* 4 */
     padding-top: 0;
     width: auto;
   }
@@ -140,7 +145,7 @@
 .input__search,
 .search__submit-btn,
 .select__search--wrapper {
-  @include abs.md-up {
+  @include abs.lg-up {
     order: 0;
   }
 }


### PR DESCRIPTION
Search form: 
- On small screens the select controls were hidden, meaning that users who magnify screen content will not be able to access that feature. Adjusts the styles so that the inline select controls drop down below the search input on md and sm screens.
- When text was resized to 200%, the search form select collapsed. Adjusted styles to align the search input, controls, and button at text sizes up to 200%.
- Removed stories for search form with no button and made the hidden label the default (removed the hideLabel story)

Alert:
-Made icon size smaller on small/magnified screens to make more space for the text.