### PR TITLE
fix: convey nested toc items semantically

### DIFF
--- a/stories/components/tableOfContents/TableOfContents.mdx
+++ b/stories/components/tableOfContents/TableOfContents.mdx
@@ -15,7 +15,7 @@ without having to scroll.
 
 ## Best practices
 
-- Use the `#toc-link-group` div id selector for building the table of contents from
+- Use the `#toc-link-group` id selector for building the table of contents from
 page headings in a script.
 
 - Optionally use `class="active"` to indicate when a specific section of contents is
@@ -42,9 +42,10 @@ The table of contents comes in a variety of colors. Use the `toc--neutral`,
 
 <Story of={stories.orange} />
 
-## Adding a title
+## Adding nested sections with link titles
 
-The table of contents can also have one or more titles to separate sections:
+The table of contents can also have one or more sections with title links. In this case,
+use nested lists to semantically convey the relationships between links.
 
 <Story of={stories.withTitle} />
 

--- a/stories/components/tableOfContents/TableOfContents.mdx
+++ b/stories/components/tableOfContents/TableOfContents.mdx
@@ -47,7 +47,7 @@ The table of contents comes in a variety of colors. Use the `toc--neutral`,
 The table of contents can also have one or more sections with title links. In this case,
 use nested lists to semantically convey the relationships between links.
 
-<Story of={stories.withTitle} />
+<Story of={stories.withSection} />
 
 ## Adding a skip link
 

--- a/stories/components/tableOfContents/TableOfContents.stories.js
+++ b/stories/components/tableOfContents/TableOfContents.stories.js
@@ -16,6 +16,6 @@ export const blue = (args) => TableOfContents({ class: 'toc--blue', ...args })
 
 export const orange = (args) => TableOfContents({ class: 'toc--orange', ...args })
 
-export const withTitle = (args) => TableOfContents({ class: 'toc--neutral', title: 'Digital Preservation Policy', ...args })
+export const withSection = (args) => TableOfContents({ class: 'toc--neutral', title: 'Digital Preservation Policy', ...args })
 
 export const skipNavigation = (args) => TableOfContents({ class: 'toc--blue', skipNavigation: true, ...args })

--- a/stories/components/tableOfContents/tableOfContents.handlebars
+++ b/stories/components/tableOfContents/tableOfContents.handlebars
@@ -3,17 +3,37 @@
   {{#if skipNavigation}}
     <a href="#documentation" class="toc__skip-link toc__skip-link--orange">Skip navigation</a>
   {{/if}}
-  <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
-  <div id="toc-link-group">
+  <ul class="toc {{class}} list--unstyled toc__list" id="toc-link-group">
+    <li>
+      <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
+      <ul class="list--unstyled toc__list">
+        {{#each listItems}}
+        <li>
+          <a class="toc__link-item {{#if this.active}}active{{/if}}" href="#{{this.text}}">{{this.text}}</a>
+        </li>
+        {{/each}}
+      </ul>
+      <a class="toc__title" href="/digital-preservation-policy/">{{title}}</a>
+      <ul class="list--unstyled toc__list">
+        {{#each listItems}}
+        <li>
+          <a class="toc__link-item {{#if this.active}}active{{/if}}" href="#{{this.text}}">{{this.text}}</a>
+        </li>
+        {{/each}}
+      </ul>
+    </li>
+  </ul>
+</nav>
+  
 {{else}}
 <nav class="toc--sticky" aria-label="{{ariaLabel}}">
   {{#if skipNavigation}}
     <a href="#documentation" class="toc__skip-link toc__skip-link--orange">Skip navigation</a>
   {{/if}}
   <div class="toc {{class}}" id="toc-link-group">
-{{/if}}
     {{#each listItems}}
-    <a class="toc__link-item {{#if this.active}}active{{/if}}" href="#{{this.text}}">{{this.text}}</a>
+      <a class="toc__link-item {{#if this.active}}active{{/if}}" href="#{{this.text}}">{{this.text}}</a>
     {{/each}}
   </div>
 </nav>
+{{/if}}

--- a/stylesheets/components/_table-of-contents.scss
+++ b/stylesheets/components/_table-of-contents.scss
@@ -22,6 +22,11 @@
   width: 100%;
 }
 
+.toc__list {
+  margin: 0;
+  padding: 0;
+}
+
 /**
 * Styles for the table of contents skip link
 **/
@@ -134,6 +139,7 @@
   border-color: abs.$regal-blue;
 }
 
-.toc__title + div .toc__link-item {
+.toc__title + div .toc__link-item,
+.toc__title + ul .toc__link-item {
   padding-left: 40px; /* 1 */
 }


### PR DESCRIPTION
When the table of contents component uses nested links (like in the RAC Docs Site that has page link titles with nested header links underneath), the relationships are conveyed to screen reader users.